### PR TITLE
feat: add landing page

### DIFF
--- a/frontend/public/mock-letter.svg
+++ b/frontend/public/mock-letter.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="600" viewBox="0 0 300 600">
+  <rect width="300" height="600" fill="#f3f4f6" />
+  <text
+    x="50%"
+    y="50%"
+    dominant-baseline="middle"
+    text-anchor="middle"
+    font-family="sans-serif"
+    font-size="20"
+    fill="#6b7280"
+  >Letter Preview</text>
+</svg>

--- a/frontend/public/stripe-badge.svg
+++ b/frontend/public/stripe-badge.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="25">
+  <text x="0" y="17" font-family="Arial, sans-serif" font-size="20" fill="#635bff">stripe</text>
+</svg>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,20 +1,5 @@
+import { LandingPage } from '../features/landing';
+
 export default function Index() {
-  return (
-    <main style={{ display: 'grid', placeItems: 'center', minHeight: '100vh' }}>
-      <a
-        href="/api/auth/google"
-        style={{
-          padding: '12px 16px',
-          borderRadius: 6,
-          border: '1px solid #e2e8f0',
-          background: 'white',
-          color: '#111827',
-          textDecoration: 'none',
-          fontWeight: 600,
-        }}
-      >
-        Continue with Google
-      </a>
-    </main>
-  );
+  return <LandingPage />;
 }

--- a/frontend/src/features/landing/components/BrandStory.tsx
+++ b/frontend/src/features/landing/components/BrandStory.tsx
@@ -1,0 +1,13 @@
+import styles from './landing.module.css';
+
+export function BrandStory() {
+  return (
+    <section className={`${styles.section} ${styles.brandStory}`}>
+      <p>
+        For years, people have said: ‘write to your MP.’ Most of us never did. MP Writer
+        makes it effortless. Powered by AI research, you can now send a perfectly
+        articulated, evidence-based letter every time your voice needs to be heard.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/features/landing/components/Footer.tsx
+++ b/frontend/src/features/landing/components/Footer.tsx
@@ -1,0 +1,14 @@
+import styles from './landing.module.css';
+
+export function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.footerLinks}>
+        <a href="/privacy">Privacy</a>
+        <a href="/terms">Terms</a>
+        <a href="/contact">Contact</a>
+      </div>
+      <div>MP Writer</div>
+    </footer>
+  );
+}

--- a/frontend/src/features/landing/components/GoogleSignInButton.tsx
+++ b/frontend/src/features/landing/components/GoogleSignInButton.tsx
@@ -1,0 +1,14 @@
+import styles from './landing.module.css';
+
+type Props = {
+  className?: string;
+};
+
+export function GoogleSignInButton({ className }: Props) {
+  return (
+    <a href="/api/auth/google" className={`${styles.googleButton} ${className ?? ''}`.trim()}>
+      <span className={styles.googleButtonAvatar} />
+      Continue with Google
+    </a>
+  );
+}

--- a/frontend/src/features/landing/components/Hero.tsx
+++ b/frontend/src/features/landing/components/Hero.tsx
@@ -1,0 +1,17 @@
+import styles from './landing.module.css';
+import { GoogleSignInButton } from './GoogleSignInButton';
+
+export function Hero() {
+  return (
+    <section className={`${styles.section} ${styles.hero}`}>
+      <h1 className={styles.headline}>Your voice, clearly heard.</h1>
+      <p className={styles.subheadline}>
+        Craft researched, respectful letters to your MP in minutes.
+      </p>
+      <GoogleSignInButton />
+      <p className={styles.trust}>
+        Secure login with Google. We’ll never post or email without your consent.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/features/landing/components/HowItWorks.tsx
+++ b/frontend/src/features/landing/components/HowItWorks.tsx
@@ -1,0 +1,31 @@
+import styles from './landing.module.css';
+
+export function HowItWorks() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.steps}>
+        <div className={styles.step}>
+          <span className={styles.stepIcon} role="img" aria-label="Map pin">📍</span>
+          <div>
+            <div className={styles.stepTitle}>Look up your MP</div>
+            <div className={styles.stepText}>Enter your postcode, we handle the rest.</div>
+          </div>
+        </div>
+        <div className={styles.step}>
+          <span className={styles.stepIcon} role="img" aria-label="Speech bubble">💬</span>
+          <div>
+            <div className={styles.stepTitle}>Describe your issue</div>
+            <div className={styles.stepText}>Tell us what matters to you.</div>
+          </div>
+        </div>
+        <div className={styles.step}>
+          <span className={styles.stepIcon} role="img" aria-label="Envelope">✉️</span>
+          <div>
+            <div className={styles.stepTitle}>Get your letter</div>
+            <div className={styles.stepText}>AI crafts drafts with citations, ready to send.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/landing/components/LandingPage.tsx
+++ b/frontend/src/features/landing/components/LandingPage.tsx
@@ -1,0 +1,24 @@
+import styles from './landing.module.css';
+import { Hero } from './Hero';
+import { HowItWorks } from './HowItWorks';
+import { BrandStory } from './BrandStory';
+import { Screenshot } from './Screenshot';
+import { Payment } from './Payment';
+import { Footer } from './Footer';
+import { GoogleSignInButton } from './GoogleSignInButton';
+
+export function LandingPage() {
+  return (
+    <>
+      <Hero />
+      <HowItWorks />
+      <BrandStory />
+      <Screenshot />
+      <Payment />
+      <Footer />
+      <div className={styles.stickyCta}>
+        <GoogleSignInButton />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/features/landing/components/Payment.tsx
+++ b/frontend/src/features/landing/components/Payment.tsx
@@ -1,0 +1,10 @@
+import styles from './landing.module.css';
+
+export function Payment() {
+  return (
+    <section className={`${styles.section} ${styles.payment}`}>
+      <p>One credit = one research & draft. Buy only what you use.</p>
+      <img src="/stripe-badge.svg" alt="Stripe" />
+    </section>
+  );
+}

--- a/frontend/src/features/landing/components/Screenshot.tsx
+++ b/frontend/src/features/landing/components/Screenshot.tsx
@@ -1,0 +1,11 @@
+import styles from './landing.module.css';
+
+export function Screenshot() {
+  return (
+    <section className={`${styles.section} ${styles.screenshot}`}>
+      <div className={styles.phoneMock}>
+        <img src="/mock-letter.svg" alt="Draft letter preview" />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/landing/components/landing.module.css
+++ b/frontend/src/features/landing/components/landing.module.css
@@ -1,0 +1,140 @@
+.section {
+  padding: 4rem 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.hero {
+  padding-top: 6rem;
+}
+
+.headline {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #003078;
+  margin-bottom: 1rem;
+}
+
+.subheadline {
+  font-size: 1.125rem;
+  color: #111827;
+  margin-bottom: 2rem;
+}
+
+.googleButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #111827;
+  font-weight: 600;
+  font-size: 1rem;
+  text-decoration: none;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  cursor: pointer;
+}
+
+.trust {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-top: 0.5rem;
+}
+
+.steps {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.step {
+  display: flex;
+  align-items: flex-start;
+  text-align: left;
+  gap: 1rem;
+}
+
+.stepIcon {
+  width: 2rem;
+  height: 2rem;
+  font-size: 2rem;
+  line-height: 2rem;
+  flex-shrink: 0;
+}
+
+.stepTitle {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.stepText {
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+
+.brandStory p {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #111827;
+}
+
+.screenshot {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+}
+
+.phoneMock {
+  border: 1px solid #e5e7eb;
+  border-radius: 1.5rem;
+  padding: 0.5rem;
+  background: #fff;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.payment p {
+  font-size: 1rem;
+  color: #111827;
+}
+
+.payment img {
+  margin-top: 0.5rem;
+  height: 20px;
+}
+
+.footer {
+  font-size: 0.875rem;
+  color: #6b7280;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem 1rem;
+}
+
+.footerLinks {
+  display: flex;
+  gap: 1rem;
+}
+
+.stickyCta {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 2rem);
+  max-width: 600px;
+}
+
+.googleButtonAvatar {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  background: #e5e7eb;
+}

--- a/frontend/src/features/landing/index.ts
+++ b/frontend/src/features/landing/index.ts
@@ -1,0 +1,1 @@
+export { LandingPage } from './components/LandingPage';


### PR DESCRIPTION
## Summary
- build landing page with hero, onboarding steps, brand story, screenshot mock, payment info, and footer
- add reusable Google sign-in button and sticky bottom CTA

## Testing
- `npx nx run frontend:lint` *(fails: Cannot find configuration for task frontend:lint)*
- `npx nx run frontend:test` *(fails: Cannot find configuration for task frontend:test)*
- `npx nx run frontend:build`
- `npx nx run frontend:typecheck` *(fails: Cannot find configuration for task frontend:typecheck)*

------
https://chatgpt.com/codex/tasks/task_e_68bc18febcac83219f52eca4fa496716