### PR TITLE
Implement credit-enforced AI workflow and writing desk

### DIFF
--- a/backend-api/src/ai/ai.controller.ts
+++ b/backend-api/src/ai/ai.controller.ts
@@ -1,16 +1,70 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AiService } from './ai.service';
 import { GenerateDto } from './dto/generate.dto';
+import { UserCreditsService } from '../user-credits/user-credits.service';
+import { UserMpService } from '../user-mp/user-mp.service';
+import { UserAddressService } from '../user-address-store/user-address.service';
 
 @UseGuards(JwtAuthGuard)
 @Controller('ai')
 export class AiController {
-  constructor(private readonly ai: AiService) {}
+  constructor(
+    private readonly ai: AiService,
+    private readonly userCredits: UserCreditsService,
+    private readonly userMp: UserMpService,
+    private readonly userAddress: UserAddressService,
+  ) {}
 
   @Post('generate')
-  async generate(@Body() body: GenerateDto) {
-    return this.ai.generate(body);
+  async generate(@Req() req: any, @Body() body: GenerateDto) {
+    const userId = req.user.id;
+    let deduction = { credits: 0 };
+    let deducted = false;
+
+    try {
+      deduction = await this.userCredits.deductFromMine(userId, 1);
+      deducted = true;
+      const [mpDoc, addressDoc] = await Promise.all([
+        this.userMp.getMine(userId).catch(() => null),
+        this.userAddress.getMine(userId).catch(() => null),
+      ]);
+
+      const mpName =
+        body.mpName ||
+        mpDoc?.mp?.name ||
+        mpDoc?.mp?.fullName ||
+        mpDoc?.mp?.displayName ||
+        '';
+      const constituency = body.constituency || mpDoc?.constituency || '';
+      const address = addressDoc?.address;
+      const addressLine =
+        body.userAddressLine ||
+        (address
+          ? [address.line1, address.line2, address.city, address.county, address.postcode]
+              .map((part: string | undefined) => (part || '').trim())
+              .filter((part: string) => Boolean(part))
+              .join(', ')
+          : '');
+
+      const payload = await this.ai.generate({
+        prompt: body.prompt,
+        model: body.model,
+        tone: body.tone,
+        details: body.details,
+        mpName,
+        constituency,
+        userName: body.userName || req.user.name || '',
+        userAddressLine: addressLine,
+      });
+
+      return { ...payload, credits: deduction.credits };
+    } catch (error: any) {
+      if (deducted) {
+        await this.userCredits.addToMine(userId, 1);
+      }
+      throw error;
+    }
   }
 }
 

--- a/backend-api/src/ai/ai.module.ts
+++ b/backend-api/src/ai/ai.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AiService } from './ai.service';
 import { AiController } from './ai.controller';
+import { UserCreditsModule } from '../user-credits/user-credits.module';
+import { UserMpModule } from '../user-mp/user-mp.module';
+import { UserAddressModule } from '../user-address-store/user-address.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, UserCreditsModule, UserMpModule, UserAddressModule],
   controllers: [AiController],
   providers: [AiService],
 })

--- a/backend-api/src/ai/ai.service.ts
+++ b/backend-api/src/ai/ai.service.ts
@@ -1,23 +1,85 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { FollowUpDetailDto } from './dto/generate.dto';
 
 @Injectable()
 export class AiService {
   constructor(private readonly config: ConfigService) {}
 
-  async generate(input: { prompt: string; model?: string }) {
+  async generate(input: {
+    prompt: string;
+    model?: string;
+    tone?: string;
+    details?: FollowUpDetailDto[];
+    mpName?: string;
+    constituency?: string;
+    userName?: string;
+    userAddressLine?: string;
+  }) {
     const apiKey = this.config.get<string>('OPENAI_API_KEY');
     const model = input.model || this.config.get<string>('OPENAI_MODEL', 'gpt-4o-mini');
+    const tone = (input.tone || '').trim();
+    const mpName = (input.mpName || '').trim();
+    const constituency = (input.constituency || '').trim();
+    const userName = (input.userName || '').trim();
+    const userAddressLine = (input.userAddressLine || '').trim();
+
+    const detailLines = (input.details || [])
+      .filter((item) => item && item.question && item.answer)
+      .map((item) => `- ${item.question.trim()}: ${item.answer.trim()}`)
+      .join('\n');
+
+    const audienceLine = mpName
+      ? `The letter is addressed to ${mpName}${constituency ? `, Member of Parliament for ${constituency}` : ''}.`
+      : 'The letter is addressed to the recipient constituent\'s Member of Parliament.';
+
+    const senderLineParts = [];
+    if (userName) senderLineParts.push(`Name: ${userName}`);
+    if (userAddressLine) senderLineParts.push(`Address: ${userAddressLine}`);
+    const senderLine = senderLineParts.length
+      ? `Include the sender information:
+${senderLineParts.map((line) => `- ${line}`).join('\n')}`
+      : 'Include a space for the sender to add their name and address if they are missing.';
+
+    const toneInstruction = tone
+      ? `Write the letter in a ${tone.toLowerCase()} tone.`
+      : 'Use a respectful and persuasive tone suitable for contacting an MP.';
+
+    const supportingDetailBlock = detailLines
+      ? `Additional background details provided by the user:
+${detailLines}`
+      : 'No additional background details were provided beyond the summary below.';
+
+    const finalPrompt = `You are MP Writer, an assistant that drafts fact-checked constituency letters with citations.
+${audienceLine}
+${senderLine}
+
+Follow these rules:
+- Produce a concise, well-structured letter ready to send.
+- Ground every claim in reputable evidence. Use numbered citations referencing trustworthy UK sources where possible.
+- Suggest specific actions for the MP to take on behalf of the constituent.
+- Close with an appreciative sign-off.
+- Keep the entire response under 500 words.
+- Return the output as markdown paragraphs with numbered references like [1], [2], etc.
+- After the signature, list the references with their source name and URL.
+
+${toneInstruction}
+
+Issue summary from the user:
+${input.prompt.trim()}
+
+${supportingDetailBlock}`;
+
     if (!apiKey) {
       // In dev without key, return a stub so flows work
-      return { content: `DEV-STUB: ${input.prompt.slice(0, 120)}...` };
+      return { content: `DEV-STUB LETTER\n\n${finalPrompt.slice(0, 400)}...` };
     }
     // Lazy import to avoid startup error if pkg missing in some envs
     const { default: OpenAI } = await import('openai');
     const client = new OpenAI({ apiKey });
     const resp = await client.chat.completions.create({
       model,
-      messages: [{ role: 'user', content: input.prompt }],
+      messages: [{ role: 'user', content: finalPrompt }],
       temperature: 0.7,
     });
     const content = resp.choices?.[0]?.message?.content ?? '';

--- a/backend-api/src/ai/dto/generate.dto.ts
+++ b/backend-api/src/ai/dto/generate.dto.ts
@@ -1,4 +1,23 @@
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+export class FollowUpDetailDto {
+  @IsString()
+  @IsNotEmpty()
+  question!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(1000)
+  answer!: string;
+}
 
 export class GenerateDto {
   @IsString()
@@ -9,5 +28,31 @@ export class GenerateDto {
   @IsString()
   @IsOptional()
   model?: string;
+
+  @IsString()
+  @IsOptional()
+  tone?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => FollowUpDetailDto)
+  details?: FollowUpDetailDto[];
+
+  @IsString()
+  @IsOptional()
+  mpName?: string;
+
+  @IsString()
+  @IsOptional()
+  constituency?: string;
+
+  @IsString()
+  @IsOptional()
+  userName?: string;
+
+  @IsString()
+  @IsOptional()
+  userAddressLine?: string;
 }
 

--- a/backend-api/src/purchases/dto/create-purchase.dto.ts
+++ b/backend-api/src/purchases/dto/create-purchase.dto.ts
@@ -1,17 +1,20 @@
 import { IsIn, IsInt, IsNotEmpty, IsOptional, IsPositive, IsString } from 'class-validator';
+import { PURCHASE_PLANS } from '../purchase-plans';
 
 export class CreatePurchaseDto {
   @IsString()
   @IsNotEmpty()
+  @IsIn(Object.keys(PURCHASE_PLANS))
   plan!: string;
 
   @IsInt()
   @IsPositive()
-  amount!: number;
+  @IsOptional()
+  amount?: number;
 
   @IsString()
   @IsOptional()
-  currency?: string = 'usd';
+  currency?: string;
 
   @IsOptional()
   metadata?: Record<string, any>;

--- a/backend-api/src/purchases/purchase-plans.ts
+++ b/backend-api/src/purchases/purchase-plans.ts
@@ -1,0 +1,34 @@
+export type PurchasePlanId = 'single' | 'starter_pack';
+
+export interface PurchasePlanConfig {
+  id: PurchasePlanId;
+  name: string;
+  credits: number;
+  amount: number;
+  currency: string;
+  description?: string;
+}
+
+export const PURCHASE_PLANS: Record<PurchasePlanId, PurchasePlanConfig> = {
+  single: {
+    id: 'single',
+    name: 'Single credit',
+    credits: 1,
+    amount: 500,
+    currency: 'gbp',
+    description: 'One AI-assisted letter generation.',
+  },
+  starter_pack: {
+    id: 'starter_pack',
+    name: 'Starter pack (5 credits)',
+    credits: 5,
+    amount: 2000,
+    currency: 'gbp',
+    description: 'Bundle of five letters at a discounted rate.',
+  },
+};
+
+export function getPurchasePlan(planId: string) {
+  if (!planId) return null;
+  return PURCHASE_PLANS[planId as PurchasePlanId] ?? null;
+}

--- a/backend-api/src/purchases/purchases.module.ts
+++ b/backend-api/src/purchases/purchases.module.ts
@@ -3,10 +3,12 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { PurchasesService } from './purchases.service';
 import { PurchasesController } from './purchases.controller';
 import { Purchase, PurchaseSchema } from './schemas/purchase.schema';
+import { UserCreditsModule } from '../user-credits/user-credits.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Purchase.name, schema: PurchaseSchema }]),
+    UserCreditsModule,
   ],
   controllers: [PurchasesController],
   providers: [PurchasesService],

--- a/backend-api/src/purchases/purchases.service.ts
+++ b/backend-api/src/purchases/purchases.service.ts
@@ -1,16 +1,43 @@
 import { InjectModel } from '@nestjs/mongoose';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { Model } from 'mongoose';
 import { Purchase } from './schemas/purchase.schema';
+import { UserCreditsService } from '../user-credits/user-credits.service';
+import { getPurchasePlan } from './purchase-plans';
 
 @Injectable()
 export class PurchasesService {
   constructor(
     @InjectModel(Purchase.name) private readonly purchaseModel: Model<Purchase>,
+    private readonly userCredits: UserCreditsService,
   ) {}
 
-  async create(userId: string, input: { plan: string; amount: number; currency?: string; metadata?: any }) {
-    return this.purchaseModel.create({ user: userId, ...input, status: 'succeeded' });
+  async create(userId: string, input: { plan: string; amount?: number; currency?: string; metadata?: any }) {
+    const plan = getPurchasePlan(input.plan);
+    if (!plan) {
+      throw new BadRequestException('Unknown purchase plan');
+    }
+
+    const amount = input.amount ?? plan.amount;
+    const currency = (input.currency ?? plan.currency).toLowerCase();
+    if (amount !== plan.amount || currency !== plan.currency) {
+      throw new BadRequestException('Purchase details do not match plan');
+    }
+
+    const purchaseDoc = await this.purchaseModel.create({
+      user: userId,
+      plan: plan.id,
+      amount,
+      currency,
+      metadata: input.metadata,
+      status: 'succeeded',
+    });
+
+    const updatedCredits = await this.userCredits.addToMine(userId, plan.credits);
+
+    const purchase = purchaseDoc.toObject ? purchaseDoc.toObject() : purchaseDoc;
+
+    return { purchase, credits: updatedCredits.credits };
   }
 
   async findMine(userId: string) {

--- a/backend-api/src/user-address-store/user-address.module.ts
+++ b/backend-api/src/user-address-store/user-address.module.ts
@@ -13,6 +13,7 @@ import { EncryptionService } from '../crypto/encryption.service';
   ],
   controllers: [UserAddressController],
   providers: [UserAddressService, EncryptionService],
+  exports: [UserAddressService, MongooseModule],
 })
 export class UserAddressModule {}
 

--- a/backend-api/src/user-mp/user-mp.module.ts
+++ b/backend-api/src/user-mp/user-mp.module.ts
@@ -8,6 +8,7 @@ import { UserMpController } from './user-mp.controller';
   imports: [MongooseModule.forFeature([{ name: UserMp.name, schema: UserMpSchema }])],
   providers: [UserMpService],
   controllers: [UserMpController],
+  exports: [UserMpService, MongooseModule],
 })
 export class UserMpModule {}
 

--- a/frontend/src/app/global.css
+++ b/frontend/src/app/global.css
@@ -1064,6 +1064,23 @@ body {
   border-color: var(--blue);
   box-shadow: 0 0 0 3px var(--ring);
 }
+.textarea {
+  appearance: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px;
+  font: inherit;
+  color: var(--ink);
+  background: #fff;
+  line-height: 1.5;
+  min-height: 140px;
+  resize: vertical;
+}
+.textarea:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--ring);
+}
 .select {
   appearance: none;
   border: 1px solid #e5e7eb;
@@ -1352,4 +1369,204 @@ body {
 .mp-meta {
   color: var(--ink-600);
   margin-top: 2px;
+}
+
+/* Writing desk */
+.writing-desk .writing-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.writing-context {
+  font-size: 0.95rem;
+  color: var(--ink-600);
+}
+
+.writing-context p {
+  margin: 4px 0;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--blue);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+}
+
+.link-button:hover,
+.link-button:focus {
+  text-decoration: underline;
+}
+
+.writing-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 14px;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #eef2ff;
+  color: var(--blue);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-secondary:hover {
+  filter: brightness(0.97);
+}
+
+.btn-tertiary {
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 12px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ink-600);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-tertiary:hover {
+  color: var(--blue);
+}
+
+.step-indicator {
+  font-weight: 600;
+  color: var(--ink-600);
+}
+
+.tone-options {
+  display: grid;
+  gap: 12px;
+}
+
+.tone-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  display: grid;
+  gap: 4px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tone-card input {
+  display: none;
+}
+
+.tone-card.selected {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--ring);
+}
+
+.tone-label {
+  font-weight: 700;
+}
+
+.tone-description {
+  color: var(--ink-600);
+  font-size: 0.95rem;
+}
+
+.review-card dl {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.review-item {
+  display: grid;
+  gap: 4px;
+}
+
+.review-card dt {
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.review-card dd {
+  margin: 0;
+  color: var(--ink-600);
+}
+
+.letter-container {
+  display: grid;
+  gap: 16px;
+}
+
+.letter-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.letter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.letter-output {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  padding: 20px;
+  color: var(--ink);
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgba(2, 8, 23, 0.02);
+}
+
+.letter-output p {
+  margin: 0 0 12px;
+}
+
+.letter-footer {
+  font-size: 0.95rem;
+  color: var(--ink-600);
+}
+
+.error-text {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.notice-text {
+  color: var(--blue);
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .writing-desk .writing-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .tone-options {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .letter-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
 }

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -1,0 +1,449 @@
+"use client";
+
+import Link from 'next/link';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+const QUESTIONS: { id: string; prompt: string }[] = [
+  { id: 'who', prompt: 'Who is most affected by this issue?' },
+  { id: 'details', prompt: 'What background or context should your MP know?' },
+  { id: 'action', prompt: 'What action would you like your MP to take?' },
+];
+
+const TONES: { id: string; label: string; description: string }[] = [
+  { id: 'formal', label: 'Formal', description: 'Polite and professional with clear respect.' },
+  { id: 'neutral', label: 'Neutral', description: 'Factual, calm and to the point.' },
+  { id: 'friendly', label: 'Friendly', description: 'Warm and conversational while staying respectful.' },
+  { id: 'urgent', label: 'Urgent', description: 'Passionate and time-sensitive but still courteous.' },
+];
+
+type Phase = 'issue' | 'questions' | 'tone' | 'review' | 'result';
+
+type UserContext = {
+  mpName: string;
+  mpEmail: string;
+  constituency: string;
+  credits: number;
+  userName: string;
+  addressLine: string;
+};
+
+export default function WritingDeskClient() {
+  const [phase, setPhase] = useState<Phase>('issue');
+  const [issue, setIssue] = useState('');
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [questionIndex, setQuestionIndex] = useState(0);
+  const [tone, setTone] = useState<string>('formal');
+  const [letter, setLetter] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [context, setContext] = useState<UserContext | null>(null);
+  const [contextMessage, setContextMessage] = useState<string>('Loading your saved details…');
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [meRes, mpRes, addressRes] = await Promise.all([
+          fetch('/api/auth/me', { credentials: 'include', cache: 'no-store' }),
+          fetch('/api/user/mp', { credentials: 'include', cache: 'no-store' }),
+          fetch('/api/user/address', { credentials: 'include', cache: 'no-store' }),
+        ]);
+
+        if (!meRes.ok) {
+          const message = meRes.status === 401
+            ? 'Please sign in to continue.'
+            : 'We could not load your profile details.';
+          if (!cancelled) {
+            setContextMessage(message);
+          }
+          return;
+        }
+
+        const me = await meRes.json();
+        const mp = mpRes.ok ? await mpRes.json() : null;
+        const addressDoc = addressRes.ok ? await addressRes.json() : null;
+        const name = (me?.name as string | undefined) || '';
+        const mpName = mp?.mp?.name || mp?.mp?.fullName || mp?.mp?.displayName || '';
+        const mpEmail = mp?.mp?.email || '';
+        const constituency = mp?.constituency || '';
+        const address = addressDoc?.address;
+        const addressLine = address
+          ? [address.line1, address.line2, address.city, address.county, address.postcode]
+              .map((part: string | undefined) => (part || '').trim())
+              .filter((part: string) => Boolean(part))
+              .join(', ')
+          : '';
+
+        if (!cancelled) {
+          setContext({
+            mpName,
+            mpEmail,
+            constituency,
+            userName: name,
+            credits: Number(me?.credits ?? 0),
+            addressLine,
+          });
+          setContextMessage('');
+        }
+      } catch (err) {
+        if (!cancelled) setContextMessage('We could not load your saved details.');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const remainingCredits = context?.credits ?? 0;
+
+  useEffect(() => {
+    if (!context) return;
+    if (!context.mpName || !context.addressLine) {
+      setContextMessage('Please return to the dashboard to confirm your MP and address before generating a letter.');
+    }
+  }, [context]);
+
+  const currentQuestion = useMemo(() => QUESTIONS[questionIndex], [questionIndex]);
+
+  function handleIssueSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!issue.trim()) {
+      setError('Please describe the issue you want to raise.');
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    setPhase('questions');
+  }
+
+  function handleQuestionSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!currentQuestion) {
+      setPhase('tone');
+      return;
+    }
+    const answer = answers[currentQuestion.id]?.trim();
+    if (!answer) {
+      setError('Please add a short answer or choose Skip.');
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    advanceQuestion();
+  }
+
+  function advanceQuestion() {
+    if (questionIndex + 1 >= QUESTIONS.length) {
+      setPhase('tone');
+      return;
+    }
+    setQuestionIndex((prev) => prev + 1);
+  }
+
+  function skipQuestion() {
+    setError(null);
+    setNotice(null);
+    advanceQuestion();
+  }
+
+  function backToPrevious() {
+    setError(null);
+    setNotice(null);
+    if (phase === 'questions') {
+      if (questionIndex === 0) {
+        setPhase('issue');
+      } else {
+        setQuestionIndex((prev) => Math.max(prev - 1, 0));
+      }
+      return;
+    }
+    if (phase === 'tone') {
+      setPhase('questions');
+      setQuestionIndex(Math.max(QUESTIONS.length - 1, 0));
+      return;
+    }
+    if (phase === 'review') {
+      setPhase('tone');
+      return;
+    }
+    if (phase === 'result') {
+      setPhase('review');
+    }
+  }
+
+  async function handleGenerate() {
+    if (!context) {
+      setError('Please sign in and set up your details first.');
+      return;
+    }
+    setIsGenerating(true);
+    setError(null);
+    setNotice(null);
+    setLetter(null);
+    try {
+      const details = QUESTIONS.map((question) => ({
+        question: question.prompt,
+        answer: answers[question.id]?.trim() || 'Not specified.',
+      }));
+      const res = await fetch('/api/ai/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt: issue,
+          tone,
+          details,
+          mpName: context.mpName,
+          constituency: context.constituency,
+          userName: context.userName,
+          userAddressLine: context.addressLine,
+        }),
+      });
+      if (!res.ok) {
+        const message = res.status === 400 || res.status === 402
+          ? 'You need at least one credit to generate a letter.'
+          : 'The AI service was unable to draft your letter just now.';
+        setError(message);
+        return;
+      }
+      const data = await res.json();
+      if (typeof data?.credits === 'number') {
+        setContext((prev) => (prev ? { ...prev, credits: data.credits } : prev));
+      }
+      if (typeof data?.content === 'string') {
+        setLetter(data.content.trim());
+        setPhase('result');
+      } else {
+        setError('We did not receive a draft. Please try again.');
+      }
+    } catch (err) {
+      setError('We could not connect to the AI service. Please try again shortly.');
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  async function copyLetter() {
+    if (!letter) return;
+    try {
+      await navigator.clipboard.writeText(letter);
+      setNotice('Letter copied to clipboard.');
+      setTimeout(() => setNotice(null), 2500);
+    } catch {
+      setError('We could not copy the letter. Please copy manually.');
+      setTimeout(() => setError(null), 3000);
+    }
+  }
+
+  return (
+    <main className="hero-section writing-desk">
+      <section className="card">
+        <div className="container writing-header">
+          <div>
+            <h1 className="section-title">Writing desk</h1>
+            <p className="section-sub">Answer a few quick questions and we will draft a fact-checked letter for you.</p>
+          </div>
+          <div className="writing-context">
+            <p><strong>Credits:</strong> {remainingCredits}</p>
+            <p>
+              Need more? Visit the <Link href="/dashboard">dashboard</Link> to buy credits.
+            </p>
+            {context?.mpEmail && (
+              <p>
+                <strong>MP email:</strong>{' '}
+                <button
+                  type="button"
+                  className="link-button"
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(context.mpEmail);
+                      setNotice('MP email copied.');
+                      setTimeout(() => setNotice(null), 2000);
+                    } catch {
+                      setError('Unable to copy email address.');
+                      setTimeout(() => setError(null), 2000);
+                    }
+                  }}
+                >
+                  {context.mpEmail}
+                </button>
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {contextMessage && (
+        <section className="card" aria-live="polite">
+          <div className="container">
+            <p>{contextMessage}</p>
+          </div>
+        </section>
+      )}
+
+      {phase === 'issue' && (
+        <section className="card">
+          <div className="container">
+            <form className="writing-form" onSubmit={handleIssueSubmit}>
+              <label htmlFor="issue" className="label">
+                What would you like to raise with your MP?
+              </label>
+              <textarea
+                id="issue"
+                name="issue"
+                className="textarea"
+                rows={6}
+                placeholder="Describe the problem or request in a few sentences."
+                value={issue}
+                onChange={(event) => setIssue(event.target.value)}
+              />
+              <div className="form-actions">
+                <button type="submit" className="btn-primary">Next</button>
+              </div>
+            </form>
+          </div>
+        </section>
+      )}
+
+      {phase === 'questions' && currentQuestion && (
+        <section className="card">
+          <div className="container">
+            <form className="writing-form" onSubmit={handleQuestionSubmit}>
+              <div className="step-indicator">
+                Step {questionIndex + 1} of {QUESTIONS.length}
+              </div>
+              <label htmlFor={`question-${currentQuestion.id}`} className="label">
+                {currentQuestion.prompt}
+              </label>
+              <textarea
+                id={`question-${currentQuestion.id}`}
+                name={currentQuestion.id}
+                className="textarea"
+                rows={4}
+                placeholder="Add a short answer."
+                value={answers[currentQuestion.id] ?? ''}
+                onChange={(event) =>
+                  setAnswers((prev) => ({ ...prev, [currentQuestion.id]: event.target.value }))
+                }
+              />
+              <div className="form-actions">
+                <button type="button" className="btn-secondary" onClick={backToPrevious}>
+                  Back
+                </button>
+                <button type="button" className="btn-tertiary" onClick={skipQuestion}>
+                  Skip
+                </button>
+                <button type="submit" className="btn-primary">
+                  {questionIndex + 1 === QUESTIONS.length ? 'Continue' : 'Next'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </section>
+      )}
+
+      {phase === 'tone' && (
+        <section className="card">
+          <div className="container">
+            <div className="tone-options" role="radiogroup" aria-label="Choose a tone for your letter">
+              {TONES.map((option) => (
+                <label key={option.id} className={`tone-card ${tone === option.id ? 'selected' : ''}`}>
+                  <input
+                    type="radio"
+                    name="tone"
+                    value={option.id}
+                    checked={tone === option.id}
+                    onChange={() => setTone(option.id)}
+                  />
+                  <span className="tone-label">{option.label}</span>
+                  <span className="tone-description">{option.description}</span>
+                </label>
+              ))}
+            </div>
+            <div className="form-actions">
+              <button type="button" className="btn-secondary" onClick={backToPrevious}>
+                Back
+              </button>
+              <button type="button" className="btn-primary" onClick={() => setPhase('review')}>
+                Review inputs
+              </button>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {phase === 'review' && (
+        <section className="card">
+          <div className="container review-card">
+            <h2 className="section-title">Review your answers</h2>
+            <dl>
+              <dt>Issue summary</dt>
+              <dd>{issue || 'Not provided'}</dd>
+              {QUESTIONS.map((question) => (
+                <div key={question.id} className="review-item">
+                  <dt>{question.prompt}</dt>
+                  <dd>{answers[question.id]?.trim() || 'Not specified'}</dd>
+                </div>
+              ))}
+              <dt>Preferred tone</dt>
+              <dd>{TONES.find((item) => item.id === tone)?.label ?? tone}</dd>
+            </dl>
+            <div className="form-actions">
+              <button type="button" className="btn-secondary" onClick={backToPrevious}>
+                Back
+              </button>
+              <button type="button" className="btn-primary" onClick={handleGenerate} disabled={isGenerating}>
+                {isGenerating ? 'Generating…' : 'Generate letter'}
+              </button>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {phase === 'result' && (
+        <section className="card">
+          <div className="container letter-container">
+            <header className="letter-header">
+              <h2 className="section-title">Your draft letter</h2>
+              <div className="letter-actions">
+                <button type="button" className="btn-secondary" onClick={backToPrevious}>
+                  Back
+                </button>
+                <button type="button" className="btn-primary" onClick={copyLetter}>
+                  Copy letter
+                </button>
+              </div>
+            </header>
+            <article className="letter-output" aria-live="polite">
+              {letter?.split('\n').map((paragraph, index) => (
+                <p key={index}>{paragraph}</p>
+              ))}
+            </article>
+            <footer className="letter-footer">
+              <p>
+                Ready to send? You can email your MP directly using their address above or paste this into your
+                preferred email client.
+              </p>
+            </footer>
+          </div>
+        </section>
+      )}
+
+      {notice && (
+        <section className="card" aria-live="polite">
+          <div className="container">
+            <p className="notice-text">{notice}</p>
+          </div>
+        </section>
+      )}
+
+      {error && (
+        <section className="card" aria-live="assertive">
+          <div className="container">
+            <p className="error-text">{error}</p>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/writingDesk/page.tsx
+++ b/frontend/src/app/writingDesk/page.tsx
@@ -1,28 +1,9 @@
-import Link from 'next/link';
+import WritingDeskClient from './WritingDeskClient';
 
 export const metadata = {
   title: 'Writing Desk — MPWriter',
 };
 
 export default function WritingDeskPage() {
-  return (
-    <main className="hero-section">
-      <section className="card">
-        <div className="container">
-          <h1 className="section-title">Writing desk</h1>
-          <p className="section-sub">Compose your message and we’ll handle the research and draft.</p>
-        </div>
-      </section>
-
-      <section className="card" style={{ marginTop: 16 }}>
-        <div className="container">
-          <p>
-            This space is reserved for the letter composer. In the meantime, you can return to the
-            {' '}<Link href="/dashboard">dashboard</Link>.
-          </p>
-        </div>
-      </section>
-    </main>
-  );
+  return <WritingDeskClient />;
 }
-

--- a/frontend/src/components/DashboardWelcome.tsx
+++ b/frontend/src/components/DashboardWelcome.tsx
@@ -3,7 +3,7 @@
 type Props = {
   firstName: string;
   credits: number;
-  onAddCredit: () => void;
+  onAddCredit: (planId: string) => void;
 };
 
 export default function DashboardWelcome({ firstName, credits, onAddCredit }: Props) {
@@ -17,8 +17,13 @@ export default function DashboardWelcome({ firstName, credits, onAddCredit }: Pr
           <p><em className="fineprint">(Saved addresses are encrypted and can only be read by you.)</em></p>
         </div>
         <div className="credits-info">
-          <button type="button" className="btn-primary btn-wide" onClick={onAddCredit}>
-            Credit shop
+          <button
+            type="button"
+            className="btn-primary btn-wide"
+            onClick={() => onAddCredit('single')}
+            aria-label="Buy one credit"
+          >
+            Buy 1 credit (£5.00)
           </button>
           <span className="credits-count">{credits} credits</span>
         </div>


### PR DESCRIPTION
## Summary
- add reusable purchase plan configuration that awards credits on successful purchases and enforce plan validation
- enforce credit deductions, gather saved MP and address context, and expand AI prompting to support tone and follow-up details
- build a multi-step Writing Desk experience with tone selection, answer capture, and styled output plus dashboard credit purchase messaging updates

## Testing
- npx nx lint backend-api *(fails: target not configured)*
- npx nx lint frontend *(fails: target not configured)*
- npx nx build backend-api --configuration=development
- npx nx build frontend --configuration=development *(fails: existing three.js dynamic import typing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68cf09b51384832186dfa06258030a15