### PR TITLE
Persist generated letters and surface history in writing desk

### DIFF
--- a/backend-api/src/ai/ai.module.ts
+++ b/backend-api/src/ai/ai.module.ts
@@ -5,9 +5,10 @@ import { AiController } from './ai.controller';
 import { UserCreditsModule } from '../user-credits/user-credits.module';
 import { UserMpModule } from '../user-mp/user-mp.module';
 import { UserAddressModule } from '../user-address-store/user-address.module';
+import { UserLettersModule } from '../user-letters/user-letters.module';
 
 @Module({
-  imports: [ConfigModule, UserCreditsModule, UserMpModule, UserAddressModule],
+  imports: [ConfigModule, UserCreditsModule, UserMpModule, UserAddressModule, UserLettersModule],
   controllers: [AiController],
   providers: [AiService],
 })

--- a/backend-api/src/app/app.module.ts
+++ b/backend-api/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { UserMpModule } from '../user-mp/user-mp.module';
 import { AddressesModule } from '../user-address/addresses.module';
 import { UserAddressModule } from '../user-address-store/user-address.module';
 import { UserCreditsModule } from '../user-credits/user-credits.module';
+import { UserLettersModule } from '../user-letters/user-letters.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { UserCreditsModule } from '../user-credits/user-credits.module';
     AddressesModule,
     UserAddressModule,
     UserCreditsModule,
+    UserLettersModule,
   ],
   controllers: [AppController, HealthController],
   providers: [

--- a/backend-api/src/user-letters/schemas/user-letter.schema.ts
+++ b/backend-api/src/user-letters/schemas/user-letter.schema.ts
@@ -1,0 +1,73 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
+
+export type UserLetterDocument = HydratedDocument<UserLetter>;
+
+@Schema({ _id: false })
+export class UserLetterDetail {
+  @Prop({ default: '' })
+  question!: string;
+
+  @Prop({ default: '' })
+  answer!: string;
+}
+
+const UserLetterDetailSchema = SchemaFactory.createForClass(UserLetterDetail);
+
+@Schema({ timestamps: true })
+export class UserLetter {
+  _id!: string;
+
+  @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'User', required: true })
+  user!: string;
+
+  @Prop({ required: true })
+  jobId!: string;
+
+  @Prop({ required: true, enum: ['queued', 'in_progress', 'completed', 'failed'] })
+  status!: string;
+
+  @Prop({ default: '' })
+  message!: string;
+
+  @Prop({ default: '' })
+  prompt!: string;
+
+  @Prop({ default: '' })
+  tone!: string;
+
+  @Prop({ type: [UserLetterDetailSchema], default: [] })
+  details!: UserLetterDetail[];
+
+  @Prop({ default: '' })
+  mpName!: string;
+
+  @Prop({ default: '' })
+  constituency!: string;
+
+  @Prop({ default: '' })
+  userName!: string;
+
+  @Prop({ default: '' })
+  userAddressLine!: string;
+
+  @Prop({ default: null })
+  ciphertext!: string | null;
+
+  @Prop({ default: null })
+  error!: string | null;
+
+  @Prop({ default: null })
+  credits!: number | null;
+
+  @Prop({ default: null })
+  lastResponseId!: string | null;
+
+  createdAt!: Date;
+
+  updatedAt!: Date;
+}
+
+export const UserLetterSchema = SchemaFactory.createForClass(UserLetter);
+UserLetterSchema.index({ user: 1, jobId: 1 }, { unique: true });
+UserLetterSchema.index({ user: 1, updatedAt: -1 });

--- a/backend-api/src/user-letters/user-letters.controller.ts
+++ b/backend-api/src/user-letters/user-letters.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, NotFoundException, Param, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { UserLettersService } from './user-letters.service';
+
+@UseGuards(JwtAuthGuard)
+@Controller('user/letters')
+export class UserLettersController {
+  constructor(private readonly letters: UserLettersService) {}
+
+  @Get()
+  async listMine(@Req() req: any) {
+    const letters = await this.letters.listMine(req.user.id);
+    return { letters };
+  }
+
+  @Get(':id')
+  async getMine(@Req() req: any, @Param('id') id: string) {
+    const letter = await this.letters.getMineById(req.user.id, id);
+    if (!letter) {
+      throw new NotFoundException('Letter not found');
+    }
+    return letter;
+  }
+}

--- a/backend-api/src/user-letters/user-letters.module.ts
+++ b/backend-api/src/user-letters/user-letters.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ConfigModule } from '@nestjs/config';
+import { UserLettersController } from './user-letters.controller';
+import { UserLettersService } from './user-letters.service';
+import { UserLetter, UserLetterSchema } from './schemas/user-letter.schema';
+import { EncryptionService } from '../crypto/encryption.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    MongooseModule.forFeature([{ name: UserLetter.name, schema: UserLetterSchema }]),
+  ],
+  controllers: [UserLettersController],
+  providers: [UserLettersService, EncryptionService],
+  exports: [UserLettersService, MongooseModule],
+})
+export class UserLettersModule {}

--- a/backend-api/src/user-letters/user-letters.service.ts
+++ b/backend-api/src/user-letters/user-letters.service.ts
@@ -96,12 +96,28 @@ export class UserLettersService {
       updatedAt: now,
     };
 
+    const setOnInsert: Record<string, unknown> = {
+      prompt: '',
+      tone: '',
+      details: [],
+      mpName: '',
+      constituency: '',
+      userName: '',
+      userAddressLine: '',
+      ciphertext: null,
+      error: payload.error ?? null,
+      credits: null,
+      lastResponseId: payload.lastResponseId ?? null,
+      createdAt: now,
+    };
+
     if (payload.message !== undefined) {
       update.message = payload.message ?? '';
     }
 
     if (payload.credits !== undefined) {
       update.credits = typeof payload.credits === 'number' ? payload.credits : null;
+      delete setOnInsert.credits;
     }
 
     if (payload.error !== undefined) {
@@ -120,20 +136,7 @@ export class UserLettersService {
       { user: payload.userId, jobId: payload.jobId },
       {
         $set: update,
-        $setOnInsert: {
-          prompt: '',
-          tone: '',
-          details: [],
-          mpName: '',
-          constituency: '',
-          userName: '',
-          userAddressLine: '',
-          ciphertext: null,
-          error: payload.error ?? null,
-          credits: typeof payload.credits === 'number' ? payload.credits : null,
-          lastResponseId: payload.lastResponseId ?? null,
-          createdAt: now,
-        },
+        $setOnInsert: setOnInsert,
       },
       { upsert: true },
     );

--- a/backend-api/src/user-letters/user-letters.service.ts
+++ b/backend-api/src/user-letters/user-letters.service.ts
@@ -1,0 +1,235 @@
+import { InjectModel } from '@nestjs/mongoose';
+import { Injectable, Logger } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { UserLetter, UserLetterDetail } from './schemas/user-letter.schema';
+import { EncryptionService } from '../crypto/encryption.service';
+
+type LetterStatus = 'queued' | 'in_progress' | 'completed' | 'failed';
+
+interface LetterDetailPayload {
+  question: string;
+  answer: string;
+}
+
+interface StartJobPayload {
+  userId: string;
+  jobId: string;
+  status: LetterStatus;
+  message: string;
+  prompt: string;
+  tone?: string;
+  details?: LetterDetailPayload[];
+  mpName?: string;
+  constituency?: string;
+  userName?: string;
+  userAddressLine?: string;
+  credits?: number | null;
+}
+
+interface SyncJobPayload {
+  userId: string;
+  jobId: string;
+  status: LetterStatus;
+  message?: string | null;
+  credits?: number | null;
+  error?: string | null;
+  content?: string | null | undefined;
+  lastResponseId?: string | null;
+}
+
+@Injectable()
+export class UserLettersService {
+  private readonly logger = new Logger(UserLettersService.name);
+
+  constructor(
+    @InjectModel(UserLetter.name) private readonly model: Model<UserLetter>,
+    private readonly enc: EncryptionService,
+  ) {}
+
+  async startJob(payload: StartJobPayload) {
+    const now = new Date();
+    const normalisedDetails: UserLetterDetail[] = (payload.details || [])
+      .map((item) => ({
+        question: (item.question || '').trim().slice(0, 500),
+        answer: (item.answer || '').trim().slice(0, 2000),
+      }))
+      .filter((item) => item.question || item.answer);
+
+    const prompt = (payload.prompt || '').trim().slice(0, 8000);
+    const tone = (payload.tone || '').trim().slice(0, 255);
+    const mpName = (payload.mpName || '').trim().slice(0, 1024);
+    const constituency = (payload.constituency || '').trim().slice(0, 1024);
+    const userName = (payload.userName || '').trim().slice(0, 1024);
+    const userAddressLine = (payload.userAddressLine || '').trim().slice(0, 2048);
+
+    await this.model.updateOne(
+      { user: payload.userId, jobId: payload.jobId },
+      {
+        $set: {
+          status: payload.status,
+          message: payload.message ?? '',
+          prompt,
+          tone,
+          details: normalisedDetails,
+          mpName,
+          constituency,
+          userName,
+          userAddressLine,
+          ciphertext: null,
+          error: null,
+          credits: typeof payload.credits === 'number' ? payload.credits : null,
+          lastResponseId: null,
+          updatedAt: now,
+        },
+        $setOnInsert: {
+          createdAt: now,
+        },
+      },
+      { upsert: true },
+    );
+  }
+
+  async syncJobState(payload: SyncJobPayload) {
+    const now = new Date();
+    const update: Record<string, unknown> = {
+      status: payload.status,
+      updatedAt: now,
+    };
+
+    if (payload.message !== undefined) {
+      update.message = payload.message ?? '';
+    }
+
+    if (payload.credits !== undefined) {
+      update.credits = typeof payload.credits === 'number' ? payload.credits : null;
+    }
+
+    if (payload.error !== undefined) {
+      update.error = payload.error ?? null;
+    }
+
+    if (payload.lastResponseId !== undefined) {
+      update.lastResponseId = payload.lastResponseId ?? null;
+    }
+
+    if (payload.content !== undefined) {
+      update.ciphertext = payload.content ? this.enc.encryptObject(payload.content) : null;
+    }
+
+    await this.model.updateOne(
+      { user: payload.userId, jobId: payload.jobId },
+      {
+        $set: update,
+        $setOnInsert: {
+          prompt: '',
+          tone: '',
+          details: [],
+          mpName: '',
+          constituency: '',
+          userName: '',
+          userAddressLine: '',
+          ciphertext: null,
+          error: payload.error ?? null,
+          credits: typeof payload.credits === 'number' ? payload.credits : null,
+          lastResponseId: payload.lastResponseId ?? null,
+          createdAt: now,
+        },
+      },
+      { upsert: true },
+    );
+  }
+
+  async getJobStatus(userId: string, jobId: string) {
+    const doc = await this.model.findOne({ user: userId, jobId }).lean();
+    if (!doc) {
+      return null;
+    }
+
+    let content: string | undefined;
+    if (doc.status === 'completed' && doc.ciphertext) {
+      try {
+        content = this.enc.decryptObject<string>(doc.ciphertext) || undefined;
+      } catch (error) {
+        this.logger.error(
+          `Failed to decrypt stored letter for job ${jobId}`,
+          error instanceof Error ? error.stack : undefined,
+        );
+      }
+    }
+
+    return {
+      jobId: doc.jobId,
+      status: doc.status as LetterStatus,
+      message: doc.message || '',
+      credits: typeof doc.credits === 'number' ? doc.credits : undefined,
+      updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.getTime() : Date.now(),
+      content,
+      error: doc.status === 'failed' ? doc.error || 'Deep research failed.' : undefined,
+    };
+  }
+
+  async listMine(userId: string, limit = 20) {
+    const docs = await this.model
+      .find({ user: userId })
+      .sort({ updatedAt: -1 })
+      .limit(limit)
+      .lean();
+
+    return docs.map((doc) => ({
+      id: doc._id?.toString?.() ?? '',
+      jobId: doc.jobId,
+      status: doc.status as LetterStatus,
+      message: doc.message || '',
+      prompt: doc.prompt || '',
+      tone: doc.tone || '',
+      mpName: doc.mpName || '',
+      constituency: doc.constituency || '',
+      hasContent: Boolean(doc.ciphertext),
+      credits: typeof doc.credits === 'number' ? doc.credits : null,
+      updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : new Date().toISOString(),
+      createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : new Date().toISOString(),
+    }));
+  }
+
+  async getMineById(userId: string, id: string) {
+    const doc = await this.model.findOne({ _id: id, user: userId }).lean();
+    if (!doc) {
+      return null;
+    }
+
+    let content: string | null = null;
+    if (doc.ciphertext) {
+      try {
+        content = this.enc.decryptObject<string>(doc.ciphertext);
+      } catch (error) {
+        this.logger.error(
+          `Failed to decrypt stored letter ${id}`,
+          error instanceof Error ? error.stack : undefined,
+        );
+      }
+    }
+
+    return {
+      id: doc._id?.toString?.() ?? '',
+      jobId: doc.jobId,
+      status: doc.status as LetterStatus,
+      message: doc.message || '',
+      prompt: doc.prompt || '',
+      tone: doc.tone || '',
+      details: (doc.details || []).map((item) => ({
+        question: item.question || '',
+        answer: item.answer || '',
+      })),
+      mpName: doc.mpName || '',
+      constituency: doc.constituency || '',
+      userName: doc.userName || '',
+      userAddressLine: doc.userAddressLine || '',
+      content,
+      error: doc.error || null,
+      credits: typeof doc.credits === 'number' ? doc.credits : null,
+      createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : new Date().toISOString(),
+      updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : new Date().toISOString(),
+    };
+  }
+}
+

--- a/frontend/src/app/global.css
+++ b/frontend/src/app/global.css
@@ -1410,6 +1410,84 @@ body {
   gap: 12px;
 }
 
+.letter-history {
+  display: grid;
+  gap: 16px;
+}
+
+.letter-history-header {
+  display: grid;
+  gap: 4px;
+}
+
+.letter-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.letter-history-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  background: #fff;
+  display: grid;
+  gap: 8px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.letter-history-item.active {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--ring);
+}
+
+.letter-history-item.in-progress {
+  border-color: #f97316;
+}
+
+.letter-history-summary {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.letter-history-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: var(--ink-600);
+  font-size: 0.9rem;
+}
+
+.letter-history-status {
+  font-weight: 700;
+}
+
+.letter-history-message {
+  margin: 0;
+  color: var(--ink-600);
+  font-size: 0.95rem;
+}
+
+.letter-history-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.letter-history-loading,
+.letter-history-empty,
+.letter-history-error {
+  color: var(--ink-600);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.letter-history-error {
+  color: #dc2626;
+}
+
 .form-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a dedicated user-letters module to persist AI letter jobs with encrypted content and expose listing/detail endpoints
- update the AI service to sync job lifecycle events to storage and fall back to saved records for status polling
- enhance the writing desk to fetch saved letters, resume in-progress jobs after reloads, and present a saved letter history UI

## Testing
- CI=1 npx nx lint backend-api
- CI=1 npx nx lint frontend *(fails: Cannot find configuration for task frontend:lint)*

------
https://chatgpt.com/codex/tasks/task_e_68d138503e5c8321a8c2c7c3251457c7