### PR TITLE
Persist AI jobs and resume generation

### DIFF
--- a/backend-api/src/ai/ai-job-completed.repository.ts
+++ b/backend-api/src/ai/ai-job-completed.repository.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { AiJobCompleted, AiJobCompletedDocument } from './schemas/ai-job-completed.schema';
+import { AiJobDetail } from './schemas/ai-job.schema';
+
+export type AiJobCompletedLean = Omit<AiJobCompletedDocument, 'save' | 'validate'> & {
+  _id: Types.ObjectId;
+};
+
+@Injectable()
+export class AiJobCompletedRepository {
+  constructor(@InjectModel(AiJobCompleted.name) private readonly completedModel: Model<AiJobCompleted>) {}
+
+  async recordCompletion(payload: {
+    jobId: string;
+    userId: string;
+    status: 'completed' | 'failed';
+    message: string;
+    credits: number | null;
+    prompt: string | null;
+    model: string | null;
+    tone: string | null;
+    details: AiJobDetail[];
+    mpName: string | null;
+    constituency: string | null;
+    userName: string | null;
+    userAddressLine: string | null;
+    content: string | null;
+    error: string | null;
+    completedAt: Date;
+  }): Promise<void> {
+    await this.completedModel
+      .findOneAndUpdate(
+        { jobId: payload.jobId },
+        {
+          $set: {
+            jobId: payload.jobId,
+            user: payload.userId,
+            status: payload.status,
+            message: payload.message,
+            credits: payload.credits ?? null,
+            prompt: payload.prompt,
+            model: payload.model,
+            tone: payload.tone,
+            details: payload.details,
+            mpName: payload.mpName,
+            constituency: payload.constituency,
+            userName: payload.userName,
+            userAddressLine: payload.userAddressLine,
+            content: payload.content,
+            error: payload.error,
+            completedAt: payload.completedAt,
+          },
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true },
+      )
+      .lean<AiJobCompletedLean>()
+      .exec();
+  }
+
+  async findByJobId(jobId: string): Promise<AiJobCompletedLean | null> {
+    return this.completedModel.findOne({ jobId }).lean<AiJobCompletedLean>().exec();
+  }
+}

--- a/backend-api/src/ai/ai-job.repository.ts
+++ b/backend-api/src/ai/ai-job.repository.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { AiJob, AiJobDocument, AiJobDetail } from './schemas/ai-job.schema';
+
+export type AiJobLean = Omit<AiJobDocument, 'save' | 'validate'> & {
+  _id: Types.ObjectId;
+};
+
+@Injectable()
+export class AiJobRepository {
+  constructor(@InjectModel(AiJob.name) private readonly jobModel: Model<AiJob>) {}
+
+  async findByUser(userId: string): Promise<AiJobLean | null> {
+    return this.jobModel.findOne({ user: userId }).lean<AiJobLean>().exec();
+  }
+
+  async findByJobId(jobId: string): Promise<AiJobLean | null> {
+    return this.jobModel.findOne({ jobId }).lean<AiJobLean>().exec();
+  }
+
+  async createOrReplace(
+    userId: string,
+    jobId: string,
+    payload: {
+      message: string;
+      status: 'queued' | 'in_progress';
+      credits: number | null;
+      prompt: string;
+      model?: string;
+      tone?: string;
+      details?: AiJobDetail[];
+      mpName?: string;
+      constituency?: string;
+      userName?: string;
+      userAddressLine?: string;
+    },
+  ): Promise<AiJobLean> {
+    const update = {
+      jobId,
+      user: userId,
+      status: payload.status,
+      message: payload.message,
+      credits: payload.credits ?? null,
+      prompt: payload.prompt,
+      model: payload.model ?? null,
+      tone: payload.tone ?? null,
+      details: payload.details ?? [],
+      mpName: payload.mpName ?? null,
+      constituency: payload.constituency ?? null,
+      userName: payload.userName ?? null,
+      userAddressLine: payload.userAddressLine ?? null,
+      content: null,
+      error: null,
+      lastResponseId: null,
+    };
+
+    return this.jobModel
+      .findOneAndUpdate(
+        { user: userId },
+        { $set: update },
+        { new: true, upsert: true, setDefaultsOnInsert: true },
+      )
+      .lean<AiJobLean>()
+      .exec();
+  }
+
+  async updateJob(jobId: string, patch: Partial<AiJob>): Promise<AiJobLean | null> {
+    return this.jobModel
+      .findOneAndUpdate(
+        { jobId },
+        { $set: patch },
+        { new: true },
+      )
+      .lean<AiJobLean>()
+      .exec();
+  }
+}

--- a/backend-api/src/ai/ai.controller.ts
+++ b/backend-api/src/ai/ai.controller.ts
@@ -32,6 +32,11 @@ export class AiController {
     });
   }
 
+  @Get('generate')
+  async getActiveJob(@Req() req: any) {
+    return this.ai.getActiveJob(req.user.id);
+  }
+
   @Get('generate/:jobId')
   async getJob(@Req() req: any, @Param('jobId') jobId: string) {
     return this.ai.getJob(jobId, req.user.id);

--- a/backend-api/src/ai/ai.module.ts
+++ b/backend-api/src/ai/ai.module.ts
@@ -1,15 +1,29 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
 import { ConfigModule } from '@nestjs/config';
 import { AiService } from './ai.service';
 import { AiController } from './ai.controller';
 import { UserCreditsModule } from '../user-credits/user-credits.module';
 import { UserMpModule } from '../user-mp/user-mp.module';
 import { UserAddressModule } from '../user-address-store/user-address.module';
+import { AiJob, AiJobSchema } from './schemas/ai-job.schema';
+import { AiJobCompleted, AiJobCompletedSchema } from './schemas/ai-job-completed.schema';
+import { AiJobRepository } from './ai-job.repository';
+import { AiJobCompletedRepository } from './ai-job-completed.repository';
 
 @Module({
-  imports: [ConfigModule, UserCreditsModule, UserMpModule, UserAddressModule],
+  imports: [
+    ConfigModule,
+    UserCreditsModule,
+    UserMpModule,
+    UserAddressModule,
+    MongooseModule.forFeature([
+      { name: AiJob.name, schema: AiJobSchema },
+      { name: AiJobCompleted.name, schema: AiJobCompletedSchema },
+    ]),
+  ],
   controllers: [AiController],
-  providers: [AiService],
+  providers: [AiService, AiJobRepository, AiJobCompletedRepository],
 })
 export class AiModule {}
 

--- a/backend-api/src/ai/schemas/ai-job-completed.schema.ts
+++ b/backend-api/src/ai/schemas/ai-job-completed.schema.ts
@@ -67,7 +67,7 @@ AiJobCompletedSchema.index({ user: 1, createdAt: -1 });
 AiJobCompletedSchema.index({ jobId: 1 }, { unique: true });
 
 AiJobCompletedSchema.set('toJSON', {
-  transform: (_doc, ret) => {
+  transform: (_doc, ret: any) => {
     ret.id = ret.jobId;
     delete ret._id;
     delete ret.__v;

--- a/backend-api/src/ai/schemas/ai-job-completed.schema.ts
+++ b/backend-api/src/ai/schemas/ai-job-completed.schema.ts
@@ -1,0 +1,76 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
+import { AiJobDetail } from './ai-job.schema';
+
+export type AiJobCompletedDocument = HydratedDocument<AiJobCompleted>;
+
+@Schema({ timestamps: true })
+export class AiJobCompleted {
+  _id!: string;
+
+  @Prop({ type: String, required: true, unique: true })
+  jobId!: string;
+
+  @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'User', required: true })
+  user!: string;
+
+  @Prop({ type: String, required: true })
+  status!: 'completed' | 'failed';
+
+  @Prop({ type: String, required: true })
+  message!: string;
+
+  @Prop({ type: Number, default: null })
+  credits!: number | null;
+
+  @Prop({ type: String, default: null })
+  prompt!: string | null;
+
+  @Prop({ type: String, default: null })
+  model!: string | null;
+
+  @Prop({ type: String, default: null })
+  tone!: string | null;
+
+  @Prop({ type: [{ question: String, answer: String }], default: [] })
+  details!: AiJobDetail[];
+
+  @Prop({ type: String, default: null })
+  mpName!: string | null;
+
+  @Prop({ type: String, default: null })
+  constituency!: string | null;
+
+  @Prop({ type: String, default: null })
+  userName!: string | null;
+
+  @Prop({ type: String, default: null })
+  userAddressLine!: string | null;
+
+  @Prop({ type: String, default: null })
+  content!: string | null;
+
+  @Prop({ type: String, default: null })
+  error!: string | null;
+
+  @Prop({ type: Date, default: () => new Date() })
+  completedAt!: Date;
+
+  createdAt!: Date;
+
+  updatedAt!: Date;
+}
+
+export const AiJobCompletedSchema = SchemaFactory.createForClass(AiJobCompleted);
+
+AiJobCompletedSchema.index({ user: 1, createdAt: -1 });
+AiJobCompletedSchema.index({ jobId: 1 }, { unique: true });
+
+AiJobCompletedSchema.set('toJSON', {
+  transform: (_doc, ret) => {
+    ret.id = ret.jobId;
+    delete ret._id;
+    delete ret.__v;
+    return ret;
+  },
+});

--- a/backend-api/src/ai/schemas/ai-job.schema.ts
+++ b/backend-api/src/ai/schemas/ai-job.schema.ts
@@ -1,0 +1,80 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
+
+export type AiJobDocument = HydratedDocument<AiJob>;
+
+export type AiJobDetail = {
+  question: string;
+  answer: string;
+};
+
+@Schema({ timestamps: true })
+export class AiJob {
+  _id!: string;
+
+  @Prop({ type: String, required: true, unique: true })
+  jobId!: string;
+
+  @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'User', required: true, unique: true })
+  user!: string;
+
+  @Prop({ type: String, required: true, enum: ['queued', 'in_progress', 'completed', 'failed'] })
+  status!: 'queued' | 'in_progress' | 'completed' | 'failed';
+
+  @Prop({ type: String, required: true })
+  message!: string;
+
+  @Prop({ type: Number, default: null })
+  credits!: number | null;
+
+  @Prop({ type: String, default: null })
+  prompt!: string | null;
+
+  @Prop({ type: String, default: null })
+  model!: string | null;
+
+  @Prop({ type: String, default: null })
+  tone!: string | null;
+
+  @Prop({ type: [{ question: String, answer: String }], default: [] })
+  details!: AiJobDetail[];
+
+  @Prop({ type: String, default: null })
+  mpName!: string | null;
+
+  @Prop({ type: String, default: null })
+  constituency!: string | null;
+
+  @Prop({ type: String, default: null })
+  userName!: string | null;
+
+  @Prop({ type: String, default: null })
+  userAddressLine!: string | null;
+
+  @Prop({ type: String, default: null })
+  content!: string | null;
+
+  @Prop({ type: String, default: null })
+  error!: string | null;
+
+  @Prop({ type: String, default: null })
+  lastResponseId!: string | null;
+
+  createdAt!: Date;
+
+  updatedAt!: Date;
+}
+
+export const AiJobSchema = SchemaFactory.createForClass(AiJob);
+
+AiJobSchema.index({ user: 1 }, { unique: true });
+AiJobSchema.index({ jobId: 1 }, { unique: true });
+
+AiJobSchema.set('toJSON', {
+  transform: (_doc, ret) => {
+    ret.id = ret.jobId;
+    delete ret._id;
+    delete ret.__v;
+    return ret;
+  },
+});

--- a/backend-api/src/ai/schemas/ai-job.schema.ts
+++ b/backend-api/src/ai/schemas/ai-job.schema.ts
@@ -71,7 +71,7 @@ AiJobSchema.index({ user: 1 }, { unique: true });
 AiJobSchema.index({ jobId: 1 }, { unique: true });
 
 AiJobSchema.set('toJSON', {
-  transform: (_doc, ret) => {
+  transform: (_doc, ret: any) => {
     ret.id = ret.jobId;
     delete ret._id;
     delete ret.__v;

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -258,7 +258,8 @@ export default function WritingDeskClient() {
     }
 
     if (typeof data.credits === 'number') {
-      setContext((prev) => (prev ? { ...prev, credits: data.credits } : prev));
+      const credits = data.credits;
+      setContext((prev) => (prev ? { ...prev, credits } : prev));
     }
 
     if (typeof data.message === 'string') {


### PR DESCRIPTION
## Summary
- store in-progress AI jobs and completed results in MongoDB via new schemas/repositories
- update the AI service/controller to enforce one active job per user and expose an active job endpoint
- resume active jobs on the writing desk, polling for completion and displaying finished letters automatically

## Testing
- npx nx lint backend-api --output-style=stream

------
https://chatgpt.com/codex/tasks/task_e_68d18a00886083219e47790bb4ab249e