### PR TITLE
feat: confirm editing intake clears follow-ups

### DIFF
--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ActiveJobResumeModal from '../../features/writing-desk/components/ActiveJobResumeModal';
+import EditIntakeConfirmModal from '../../features/writing-desk/components/EditIntakeConfirmModal';
 import { useActiveWritingDeskJob } from '../../features/writing-desk/hooks/useActiveWritingDeskJob';
 import { ActiveWritingDeskJob, UpsertActiveWritingDeskJobPayload } from '../../features/writing-desk/types';
 
@@ -78,6 +79,7 @@ export default function WritingDeskClient() {
   const [persistenceEnabled, setPersistenceEnabled] = useState(false);
   const lastPersistedRef = useRef<string | null>(null);
   const [jobSaveError, setJobSaveError] = useState<string | null>(null);
+  const [editIntakeModalOpen, setEditIntakeModalOpen] = useState(false);
 
   const currentStep = phase === 'initial' ? steps[stepIndex] ?? null : null;
   const followUpCreditCost = 0.1;
@@ -576,6 +578,16 @@ export default function WritingDeskClient() {
     [],
   );
 
+  const handleConfirmEditIntake = useCallback(() => {
+    resetFollowUps();
+    setEditIntakeModalOpen(false);
+    handleEditInitialStep('issueDetail');
+  }, [handleEditInitialStep, resetFollowUps]);
+
+  const handleCancelEditIntake = useCallback(() => {
+    setEditIntakeModalOpen(false);
+  }, []);
+
   const handleEditFollowUpQuestion = useCallback((index: number) => {
     if (index < 0 || index >= followUps.length) return;
     setServerError(null);
@@ -590,6 +602,12 @@ export default function WritingDeskClient() {
 
   return (
     <>
+      <EditIntakeConfirmModal
+        open={editIntakeModalOpen}
+        creditCost={formatCredits(followUpCreditCost)}
+        onConfirm={handleConfirmEditIntake}
+        onCancel={handleCancelEditIntake}
+      />
       <ActiveJobResumeModal
         open={resumeModalOpen}
         job={pendingJob}
@@ -820,24 +838,8 @@ export default function WritingDeskClient() {
               <div className="stack" style={{ marginTop: 12 }}>
                 {steps.map((step) => (
                   <div key={step.key} style={{ marginBottom: 16 }}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        gap: 12,
-                      }}
-                    >
+                    <div>
                       <h5 style={{ margin: 0, fontWeight: 600, fontSize: '1rem' }}>{step.title}</h5>
-                      <button
-                        type="button"
-                        className="btn-link"
-                        onClick={() => handleEditInitialStep(step.key)}
-                        aria-label={`Edit “${step.title}”`}
-                        disabled={loading}
-                      >
-                        Edit
-                      </button>
                     </div>
                     <p style={{ margin: '6px 0 0 0' }}>{form[step.key]}</p>
                   </div>
@@ -903,7 +905,7 @@ export default function WritingDeskClient() {
               <button
                 type="button"
                 className="btn-secondary"
-                onClick={() => handleEditInitialStep('issueDetail')}
+                onClick={() => setEditIntakeModalOpen(true)}
                 disabled={loading}
               >
                 Edit intake answers

--- a/frontend/src/features/writing-desk/components/EditIntakeConfirmModal.tsx
+++ b/frontend/src/features/writing-desk/components/EditIntakeConfirmModal.tsx
@@ -1,0 +1,87 @@
+interface EditIntakeConfirmModalProps {
+  open: boolean;
+  creditCost: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function EditIntakeConfirmModal({
+  open,
+  creditCost,
+  onConfirm,
+  onCancel,
+}: EditIntakeConfirmModalProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-intake-confirm-title"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: 'rgba(15, 23, 42, 0.45)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 420,
+          width: '100%',
+          background: 'white',
+          borderRadius: 16,
+          boxShadow: '0 20px 45px rgba(15, 23, 42, 0.25)',
+          padding: '24px 28px',
+        }}
+      >
+        <h2 id="edit-intake-confirm-title" style={{ fontSize: 24, lineHeight: 1.2, marginBottom: 12 }}>
+          Edit intake answers?
+        </h2>
+        <p style={{ marginBottom: 16, color: '#334155', lineHeight: 1.6 }}>
+          Editing your intake answers will clear your existing follow-up questions and answers. New
+          follow-up questions will need to be generated at a cost of {creditCost} credits.
+        </p>
+        <p style={{ marginBottom: 20, color: '#475569' }}>Do you want to continue?</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <button
+            type="button"
+            onClick={onConfirm}
+            style={{
+              backgroundColor: '#2563eb',
+              color: 'white',
+              border: 'none',
+              borderRadius: 999,
+              padding: '12px 20px',
+              fontSize: 16,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Yes, edit intake
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{
+              backgroundColor: 'transparent',
+              color: '#1f2937',
+              border: '1px solid #cbd5f5',
+              borderRadius: 999,
+              padding: '12px 20px',
+              fontSize: 16,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            No, keep current answers
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a confirmation modal before editing intake answers from the summary view
- clear stored follow-up questions/answers when intake editing is confirmed and remove per-answer edit links

## Testing
- CI=1 npx nx test frontend --runInBand --testPathPattern=WritingDeskClient.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6b049fe7c8321a1e7aad58630d06e