### PR TITLE
Encrypt writing desk inputs

### DIFF
--- a/backend-api/src/writing-desk-jobs/schema/writing-desk-job.schema.ts
+++ b/backend-api/src/writing-desk-jobs/schema/writing-desk-job.schema.ts
@@ -19,29 +19,14 @@ export class WritingDeskJob {
   @Prop({ type: Number, required: true, min: 0 })
   followUpIndex!: number;
 
-  @Prop({
-    type: {
-      issueDetail: { type: String, default: '' },
-      affectedDetail: { type: String, default: '' },
-      backgroundDetail: { type: String, default: '' },
-      desiredOutcome: { type: String, default: '' },
-    },
-    required: true,
-    _id: false,
-    default: {},
-  })
-  form!: {
-    issueDetail: string;
-    affectedDetail: string;
-    backgroundDetail: string;
-    desiredOutcome: string;
-  };
+  @Prop({ type: String, required: true })
+  formCiphertext!: string;
 
   @Prop({ type: [String], default: [] })
   followUpQuestions!: string[];
 
-  @Prop({ type: [String], default: [] })
-  followUpAnswers!: string[];
+  @Prop({ type: String, required: true })
+  followUpAnswersCiphertext!: string;
 
   @Prop({ type: String, default: null })
   notes!: string | null;

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.module.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.module.ts
@@ -4,11 +4,12 @@ import { WritingDeskJobsController } from './writing-desk-jobs.controller';
 import { WritingDeskJobsService } from './writing-desk-jobs.service';
 import { WritingDeskJobsRepository } from './writing-desk-jobs.repository';
 import { WritingDeskJob, WritingDeskJobSchema } from './schema/writing-desk-job.schema';
+import { EncryptionService } from '../crypto/encryption.service';
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: WritingDeskJob.name, schema: WritingDeskJobSchema }])],
   controllers: [WritingDeskJobsController],
-  providers: [WritingDeskJobsService, WritingDeskJobsRepository],
+  providers: [WritingDeskJobsService, WritingDeskJobsRepository, EncryptionService],
   exports: [WritingDeskJobsService],
 })
 export class WritingDeskJobsModule {}

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
@@ -24,6 +24,23 @@ export interface WritingDeskJobSnapshot {
   updatedAt: Date;
 }
 
+export interface WritingDeskJobRecord {
+  jobId: string;
+  userId: string;
+  phase: WritingDeskJobPhase;
+  stepIndex: number;
+  followUpIndex: number;
+  followUpQuestions: string[];
+  formCiphertext?: string;
+  followUpAnswersCiphertext?: string;
+  form?: WritingDeskJobFormSnapshot;
+  followUpAnswers?: string[];
+  notes: string | null;
+  responseId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface ActiveWritingDeskJobResource {
   jobId: string;
   phase: WritingDeskJobPhase;


### PR DESCRIPTION
## Summary
- encrypt writing desk writing inputs and follow-up answers at rest using the shared encryption service
- update the repository layer to persist ciphertext, clear legacy plaintext fields, and expose a record type for decryption
- provide the encryption service via the module so writing desk jobs can decrypt when reading and return the same API resource

## Testing
- npx nx lint backend-api *(fails: Cannot find configuration for task backend-api:lint)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c1a64aa88321b349fd9c28ff9153