### PR TITLE
Add writing desk research phase

### DIFF
--- a/backend-api/src/writing-desk-jobs/schema/writing-desk-job.schema.ts
+++ b/backend-api/src/writing-desk-jobs/schema/writing-desk-job.schema.ts
@@ -1,6 +1,11 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
-import { WRITING_DESK_JOB_PHASES, WritingDeskJobPhase } from '../writing-desk-jobs.types';
+import {
+  WRITING_DESK_JOB_PHASES,
+  WRITING_DESK_RESEARCH_STATUSES,
+  WritingDeskJobPhase,
+  WritingDeskResearchStatus,
+} from '../writing-desk-jobs.types';
 
 @Schema({ timestamps: true })
 export class WritingDeskJob {
@@ -33,6 +38,51 @@ export class WritingDeskJob {
 
   @Prop({ type: String, default: null })
   responseId!: string | null;
+
+  @Prop({ type: String, enum: WRITING_DESK_RESEARCH_STATUSES, default: 'idle' })
+  researchStatus!: WritingDeskResearchStatus;
+
+  @Prop({ type: Number, default: 0, min: 0, max: 100 })
+  researchProgress!: number;
+
+  @Prop({
+    type: [
+      {
+        id: { type: String, required: true },
+        type: { type: String, required: true },
+        message: { type: String, required: true },
+        createdAt: { type: Date, required: true },
+      },
+    ],
+    default: [],
+  })
+  researchActions!: Array<{
+    id: string;
+    type: string;
+    message: string;
+    createdAt: Date;
+  }>;
+
+  @Prop({ type: String, default: null })
+  researchResult!: string | null;
+
+  @Prop({ type: String, default: null })
+  researchResponseId!: string | null;
+
+  @Prop({ type: String, default: null })
+  researchError!: string | null;
+
+  @Prop({ type: Date, default: null })
+  researchStartedAt!: Date | null;
+
+  @Prop({ type: Date, default: null })
+  researchCompletedAt!: Date | null;
+
+  @Prop({ type: Number, default: null })
+  researchBilledCredits!: number | null;
+
+  @Prop({ type: Number, default: 0 })
+  researchCursor!: number;
 }
 
 export type WritingDeskJobDocument = WritingDeskJob & Document;

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.controller.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Put, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Post, Put, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { WritingDeskJobsService } from './writing-desk-jobs.service';
 import { UpsertActiveWritingDeskJobDto } from './dto/upsert-active-writing-desk-job.dto';
@@ -16,6 +16,16 @@ export class WritingDeskJobsController {
   @Put()
   async upsertActiveJob(@Req() req: any, @Body() body: UpsertActiveWritingDeskJobDto) {
     return this.jobs.upsertActiveJob(req.user.id, body);
+  }
+
+  @Post('research/start')
+  async startResearch(@Req() req: any) {
+    return this.jobs.startResearch(req.user.id);
+  }
+
+  @Get('research/status')
+  async getResearchStatus(@Req() req: any) {
+    return this.jobs.refreshResearchStatus(req.user.id);
   }
 
   @Delete()

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.module.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.module.ts
@@ -1,13 +1,19 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { WritingDeskJobsController } from './writing-desk-jobs.controller';
 import { WritingDeskJobsService } from './writing-desk-jobs.service';
 import { WritingDeskJobsRepository } from './writing-desk-jobs.repository';
 import { WritingDeskJob, WritingDeskJobSchema } from './schema/writing-desk-job.schema';
 import { EncryptionService } from '../crypto/encryption.service';
+import { UserCreditsModule } from '../user-credits/user-credits.module';
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: WritingDeskJob.name, schema: WritingDeskJobSchema }])],
+  imports: [
+    ConfigModule,
+    UserCreditsModule,
+    MongooseModule.forFeature([{ name: WritingDeskJob.name, schema: WritingDeskJobSchema }]),
+  ],
   controllers: [WritingDeskJobsController],
   providers: [WritingDeskJobsService, WritingDeskJobsRepository, EncryptionService],
   exports: [WritingDeskJobsService],

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.repository.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.repository.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { WritingDeskJob, WritingDeskJobDocument } from './schema/writing-desk-job.schema';
-import { WritingDeskJobRecord, WritingDeskJobPhase } from './writing-desk-jobs.types';
+import {
+  WritingDeskJobPersistencePayload,
+  WritingDeskJobRecord,
+  WritingDeskJobResearchUpdatePayload,
+} from './writing-desk-jobs.types';
 
 @Injectable()
 export class WritingDeskJobsRepository {
@@ -18,17 +22,7 @@ export class WritingDeskJobsRepository {
 
   async upsertActiveJob(
     userId: string,
-    payload: {
-      jobId: string;
-      phase: WritingDeskJobPhase;
-      stepIndex: number;
-      followUpIndex: number;
-      followUpQuestions: string[];
-      formCiphertext: string;
-      followUpAnswersCiphertext: string;
-      notes: string | null;
-      responseId: string | null;
-    },
+    payload: WritingDeskJobPersistencePayload,
   ): Promise<WritingDeskJobRecord> {
     const doc = await this.model
       .findOneAndUpdate(
@@ -48,5 +42,23 @@ export class WritingDeskJobsRepository {
 
   async deleteActiveJob(userId: string): Promise<void> {
     await this.model.deleteOne({ userId });
+  }
+
+  async updateResearchState(
+    userId: string,
+    updates: WritingDeskJobResearchUpdatePayload,
+  ): Promise<WritingDeskJobRecord | null> {
+    const doc = await this.model
+      .findOneAndUpdate(
+        { userId },
+        {
+          $set: {
+            ...updates,
+          },
+        },
+        { new: true }
+      )
+      .lean();
+    return doc ? (doc as unknown as WritingDeskJobRecord) : null;
   }
 }

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.service.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.service.ts
@@ -1,20 +1,36 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import { UpsertActiveWritingDeskJobDto } from './dto/upsert-active-writing-desk-job.dto';
 import { WritingDeskJobsRepository } from './writing-desk-jobs.repository';
 import {
   ActiveWritingDeskJobResource,
+  WritingDeskJobPersistencePayload,
   WritingDeskJobSnapshot,
   WritingDeskJobFormSnapshot,
   WritingDeskJobRecord,
+  WritingDeskJobResearchSnapshot,
+  WritingDeskJobResearchUpdatePayload,
+  WritingDeskResearchActionSnapshot,
+  WritingDeskResearchStatus,
 } from './writing-desk-jobs.types';
 import { EncryptionService } from '../crypto/encryption.service';
+import { UserCreditsService } from '../user-credits/user-credits.service';
+
+const RESEARCH_CREDIT_COST = 0.7;
+const MAX_RESEARCH_ACTIONS = 50;
+const FINAL_RESEARCH_STATUSES: WritingDeskResearchStatus[] = ['completed', 'failed', 'cancelled'];
 
 @Injectable()
 export class WritingDeskJobsService {
+  private readonly logger = new Logger(WritingDeskJobsService.name);
+  private openaiClient: any | null = null;
+
   constructor(
     private readonly repository: WritingDeskJobsRepository,
     private readonly encryption: EncryptionService,
+    private readonly config: ConfigService,
+    private readonly userCredits: UserCreditsService,
   ) {}
 
   async getActiveJobForUser(userId: string): Promise<ActiveWritingDeskJobResource | null> {
@@ -28,10 +44,11 @@ export class WritingDeskJobsService {
     userId: string,
     input: UpsertActiveWritingDeskJobDto,
   ): Promise<ActiveWritingDeskJobResource> {
-    const existing = await this.repository.findActiveByUserId(userId);
-    const sanitized = this.sanitiseInput(input);
-    const nextJobId = this.resolveJobId(existing, input.jobId);
-    const payload = {
+    const existingRecord = await this.repository.findActiveByUserId(userId);
+    const existingSnapshot = existingRecord ? this.toSnapshot(existingRecord) : null;
+    const sanitized = this.sanitiseInput(input, existingSnapshot);
+    const nextJobId = this.resolveJobId(existingRecord, input.jobId);
+    const payload: WritingDeskJobPersistencePayload = {
       jobId: nextJobId,
       phase: sanitized.phase,
       stepIndex: sanitized.stepIndex,
@@ -41,6 +58,16 @@ export class WritingDeskJobsService {
       followUpAnswersCiphertext: this.encryption.encryptObject(sanitized.followUpAnswers),
       notes: sanitized.notes,
       responseId: sanitized.responseId,
+      researchStatus: sanitized.research.status,
+      researchProgress: sanitized.research.progress,
+      researchActions: sanitized.research.actions,
+      researchResult: sanitized.research.result,
+      researchResponseId: sanitized.research.responseId,
+      researchError: sanitized.research.error,
+      researchStartedAt: sanitized.research.startedAt,
+      researchCompletedAt: sanitized.research.completedAt,
+      researchBilledCredits: sanitized.research.billedCredits,
+      researchCursor: sanitized.research.cursor,
     };
 
     const saved = await this.repository.upsertActiveJob(userId, payload);
@@ -50,6 +77,136 @@ export class WritingDeskJobsService {
 
   async deleteActiveJob(userId: string): Promise<void> {
     await this.repository.deleteActiveJob(userId);
+  }
+
+  async startResearch(userId: string): Promise<{ job: ActiveWritingDeskJobResource; remainingCredits: number | null }> {
+    const record = await this.repository.findActiveByUserId(userId);
+    if (!record) {
+      throw new NotFoundException('No active writing desk job found');
+    }
+
+    const snapshot = this.toSnapshot(record);
+    const currentResearch = snapshot.research;
+    if (!FINAL_RESEARCH_STATUSES.includes(currentResearch.status) && currentResearch.status !== 'idle') {
+      const { credits } = await this.userCredits.getMine(userId);
+      return { job: this.toResource(snapshot), remainingCredits: credits };
+    }
+
+    const { credits: remainingCredits } = await this.userCredits.deductFromMine(userId, RESEARCH_CREDIT_COST);
+    const apiKey = this.config.get<string>('OPENAI_API_KEY')?.trim();
+    const researchModel = this.config.get<string>('OPENAI_DEEP_RESEARCH_MODEL')?.trim() || 'o4-mini-deep-research';
+    const now = new Date();
+
+    if (!apiKey) {
+      const stubResult = this.buildStubResearch(snapshot);
+      const stubUpdates: WritingDeskJobResearchUpdatePayload = {
+        phase: 'research',
+        researchStatus: 'completed',
+        researchProgress: 100,
+        researchActions: [],
+        researchResult: stubResult,
+        researchResponseId: 'dev-stub',
+        researchError: null,
+        researchStartedAt: now,
+        researchCompletedAt: now,
+        researchBilledCredits: RESEARCH_CREDIT_COST,
+        researchCursor: 0,
+      };
+      const updated = await this.repository.updateResearchState(userId, stubUpdates);
+      if (!updated) throw new NotFoundException('Unable to update research state');
+      return { job: this.toResource(this.toSnapshot(updated)), remainingCredits };
+    }
+
+    try {
+      const client = await this.getOpenAiClient(apiKey);
+      const vectorStoreIds = this.parseVectorStoreIds();
+      const prompt = this.buildResearchPrompt(snapshot);
+      const tools = this.buildResearchTools(vectorStoreIds);
+
+      const response = await client.responses.create({
+        model: researchModel,
+        input: prompt,
+        background: true,
+        store: true,
+        reasoning: { effort: 'medium', summary: 'auto' },
+        tools,
+        metadata: {
+          feature: 'writing-desk-research',
+          jobId: snapshot.jobId,
+        },
+      });
+
+      const status = this.mapOpenAiStatus(response?.status);
+      const initialProgress = status === 'queued' ? 0 : status === 'completed' ? 100 : 5;
+      const initialCursor = Array.isArray(response?.output) ? response.output.length : 0;
+
+      const updates: WritingDeskJobResearchUpdatePayload = {
+        phase: 'research',
+        researchStatus: status,
+        researchProgress: this.clampProgress(initialProgress),
+        researchActions: [],
+        researchResult: null,
+        researchResponseId: response?.id ?? null,
+        researchError: null,
+        researchStartedAt: now,
+        researchCompletedAt: null,
+        researchBilledCredits: RESEARCH_CREDIT_COST,
+        researchCursor: initialCursor,
+      };
+
+      const updated = await this.repository.updateResearchState(userId, updates);
+      if (!updated) throw new NotFoundException('Unable to update research state');
+
+      return { job: this.toResource(this.toSnapshot(updated)), remainingCredits };
+    } catch (error) {
+      await this.refundCredits(userId, RESEARCH_CREDIT_COST);
+      this.logger.error(`Failed to start deep research for job ${snapshot.jobId}: ${(error as Error).message}`);
+      throw error;
+    }
+  }
+
+  async refreshResearchStatus(userId: string): Promise<ActiveWritingDeskJobResource | null> {
+    const record = await this.repository.findActiveByUserId(userId);
+    if (!record) return null;
+
+    const snapshot = this.toSnapshot(record);
+    const research = snapshot.research;
+
+    if (!research.responseId || FINAL_RESEARCH_STATUSES.includes(research.status)) {
+      return this.toResource(snapshot);
+    }
+
+    const apiKey = this.config.get<string>('OPENAI_API_KEY')?.trim();
+    if (!apiKey) {
+      return this.toResource(snapshot);
+    }
+
+    try {
+      const client = await this.getOpenAiClient(apiKey);
+      const response = await client.responses.retrieve(research.responseId);
+      const updates = this.buildResearchUpdateFromResponse(snapshot, response);
+      const updated = await this.repository.updateResearchState(userId, updates);
+      if (!updated) throw new NotFoundException('Unable to update research state');
+      return this.toResource(this.toSnapshot(updated));
+    } catch (error) {
+      this.logger.error(`Failed to refresh deep research for job ${snapshot.jobId}: ${(error as Error).message}`);
+      const fallbackUpdates: WritingDeskJobResearchUpdatePayload = {
+        phase: 'research',
+        researchStatus: 'failed',
+        researchProgress: 100,
+        researchActions: research.actions,
+        researchResult: research.result,
+        researchResponseId: research.responseId,
+        researchError: (error as Error)?.message ?? 'Deep research request failed',
+        researchStartedAt: research.startedAt ?? new Date(),
+        researchCompletedAt: new Date(),
+        researchBilledCredits: research.billedCredits,
+        researchCursor: research.cursor,
+      };
+      const updated = await this.repository.updateResearchState(userId, fallbackUpdates);
+      if (!updated) throw new NotFoundException('Unable to update research state');
+      return this.toResource(this.toSnapshot(updated));
+    }
   }
 
   private resolveJobId(existing: { jobId: string } | null, requestedJobId: string | undefined) {
@@ -62,7 +219,10 @@ export class WritingDeskJobsService {
     return randomUUID();
   }
 
-  private sanitiseInput(input: UpsertActiveWritingDeskJobDto) {
+  private sanitiseInput(
+    input: UpsertActiveWritingDeskJobDto,
+    existing: WritingDeskJobSnapshot | null,
+  ) {
     const trim = (value: string | undefined | null) => (typeof value === 'string' ? value : '');
     const trimNullable = (value: string | undefined) => {
       if (typeof value !== 'string') return null;
@@ -96,6 +256,8 @@ export class WritingDeskJobsService {
       ? Math.min(Math.floor(input.followUpIndex), Math.max(maxFollowUps - 1, 0))
       : 0;
 
+    const research = existing?.research ?? this.buildDefaultResearchSnapshot();
+
     return {
       phase: input.phase,
       stepIndex,
@@ -105,12 +267,29 @@ export class WritingDeskJobsService {
       followUpAnswers: alignedAnswers,
       notes: trimNullable(input.notes),
       responseId: trimNullable(input.responseId),
+      research,
+    };
+  }
+
+  private buildDefaultResearchSnapshot(): WritingDeskJobResearchSnapshot {
+    return {
+      status: 'idle',
+      progress: 0,
+      actions: [],
+      result: null,
+      responseId: null,
+      error: null,
+      startedAt: null,
+      completedAt: null,
+      billedCredits: null,
+      cursor: 0,
     };
   }
 
   private toSnapshot(record: WritingDeskJobRecord): WritingDeskJobSnapshot {
     const form = this.decryptForm(record);
     const followUpAnswers = this.decryptFollowUpAnswers(record);
+    const research = this.resolveResearchSnapshot(record);
 
     const createdAt = record.createdAt instanceof Date ? record.createdAt : new Date(record.createdAt);
     const updatedAt = record.updatedAt instanceof Date ? record.updatedAt : new Date(record.updatedAt);
@@ -126,8 +305,59 @@ export class WritingDeskJobsService {
       followUpAnswers,
       notes: record.notes ?? null,
       responseId: record.responseId ?? null,
+      research,
       createdAt,
       updatedAt,
+    };
+  }
+
+  private resolveResearchSnapshot(record: WritingDeskJobRecord): WritingDeskJobResearchSnapshot {
+    const status = this.normaliseResearchStatus(record.researchStatus);
+    const progress = typeof record.researchProgress === 'number' ? this.clampProgress(record.researchProgress) : 0;
+    const rawActions = Array.isArray(record.researchActions) ? record.researchActions : [];
+
+    const actions: WritingDeskResearchActionSnapshot[] = rawActions
+      .map((item) => {
+        const createdAt = item?.createdAt instanceof Date
+          ? item.createdAt
+          : item?.createdAt
+            ? new Date(item.createdAt)
+            : new Date();
+        return {
+          id: typeof item?.id === 'string' && item.id.trim().length > 0 ? item.id : randomUUID(),
+          type: typeof item?.type === 'string' && item.type.trim().length > 0 ? item.type : 'activity',
+          message: typeof item?.message === 'string' ? item.message : '',
+          createdAt,
+        };
+      })
+      .filter((action) => action.message.trim().length > 0);
+
+    const startedAt = record.researchStartedAt
+      ? record.researchStartedAt instanceof Date
+        ? record.researchStartedAt
+        : new Date(record.researchStartedAt)
+      : null;
+
+    const completedAt = record.researchCompletedAt
+      ? record.researchCompletedAt instanceof Date
+        ? record.researchCompletedAt
+        : new Date(record.researchCompletedAt)
+      : null;
+
+    const billedCredits = typeof record.researchBilledCredits === 'number' ? record.researchBilledCredits : null;
+    const cursor = typeof record.researchCursor === 'number' ? record.researchCursor : 0;
+
+    return {
+      status,
+      progress,
+      actions,
+      result: record.researchResult ?? null,
+      responseId: record.researchResponseId ?? null,
+      error: record.researchError ?? null,
+      startedAt,
+      completedAt,
+      billedCredits,
+      cursor,
     };
   }
 
@@ -187,9 +417,286 @@ export class WritingDeskJobsService {
       followUpAnswers: snapshot.followUpAnswers,
       notes: snapshot.notes ?? null,
       responseId: snapshot.responseId ?? null,
+      research: this.researchSnapshotToResource(snapshot.research),
       createdAt: snapshot.createdAt?.toISOString?.() ?? new Date().toISOString(),
       updatedAt: snapshot.updatedAt?.toISOString?.() ?? new Date().toISOString(),
     };
+  }
+
+  private researchSnapshotToResource(research: WritingDeskJobResearchSnapshot) {
+    return {
+      status: research.status,
+      progress: this.clampProgress(research.progress),
+      actions: research.actions
+        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+        .slice(-MAX_RESEARCH_ACTIONS)
+        .map((action) => ({
+          id: action.id,
+          type: action.type,
+          message: action.message,
+          createdAt: action.createdAt.toISOString(),
+        })),
+      result: research.result ?? null,
+      responseId: research.responseId ?? null,
+      error: research.error ?? null,
+      startedAt: research.startedAt ? research.startedAt.toISOString() : null,
+      completedAt: research.completedAt ? research.completedAt.toISOString() : null,
+      billedCredits: research.billedCredits ?? null,
+    };
+  }
+
+  private normaliseResearchStatus(value: string | null | undefined): WritingDeskResearchStatus {
+    if (!value) return 'idle';
+    switch (value) {
+      case 'queued':
+      case 'in_progress':
+      case 'completed':
+      case 'failed':
+      case 'cancelled':
+      case 'idle':
+        return value;
+      default:
+        return 'in_progress';
+    }
+  }
+
+  private clampProgress(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    if (value < 0) return 0;
+    if (value > 100) return 100;
+    return Math.round(value * 10) / 10;
+  }
+
+  private async getOpenAiClient(apiKey: string) {
+    if (this.openaiClient) return this.openaiClient;
+    const { default: OpenAI } = await import('openai');
+    this.openaiClient = new OpenAI({ apiKey, timeout: 1000 * 60 * 15 });
+    return this.openaiClient;
+  }
+
+  private parseVectorStoreIds(): string[] {
+    const raw = this.config.get<string>('OPENAI_DEEP_RESEARCH_VECTOR_STORE_IDS');
+    if (!raw) return [];
+    return raw
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+  }
+
+  private buildResearchPrompt(snapshot: WritingDeskJobSnapshot): string {
+    const followUps = snapshot.followUpQuestions
+      .map((question, idx) => {
+        const answer = snapshot.followUpAnswers[idx] ?? '';
+        return `Follow-up ${idx + 1}:\nQuestion: ${question}\nAnswer: ${answer}`;
+      })
+      .join('\n\n');
+
+    return `You are an expert researcher preparing evidence for a UK constituent's letter to their Member of Parliament.
+Use credible, current sources (official statistics, government publications, reputable news, NGOs, academic papers).
+Return only raw research notes, not the letter itself.
+
+Context for the case:
+- Issue detail: ${snapshot.form.issueDetail}
+- Who is affected: ${snapshot.form.affectedDetail}
+- Background: ${snapshot.form.backgroundDetail}
+- Desired outcome: ${snapshot.form.desiredOutcome}
+
+Additional clarifications:
+${followUps || 'No additional follow-up answers were provided.'}
+
+Task:
+- Investigate the situation thoroughly.
+- Provide organised bullet points grouped by theme (e.g. Impact, Legal obligations, Recent developments, Support avenues).
+- Each bullet must include inline citations with the source title and a direct URL in Markdown.
+- Highlight specific facts, statistics, quotes, deadlines, regulatory requirements, and authoritative guidance.
+- Do not draft the letter or provide prose beyond the research notes.`;
+  }
+
+  private buildResearchTools(vectorStoreIds: string[]) {
+    const tools: any[] = [{ type: 'web_search_preview' }];
+    if (vectorStoreIds.length > 0) {
+      tools.push({ type: 'file_search', vector_store_ids: vectorStoreIds });
+    }
+    tools.push({ type: 'code_interpreter', container: { type: 'auto' } });
+    return tools;
+  }
+
+  private mapOpenAiStatus(status: string | undefined): WritingDeskResearchStatus {
+    switch (status) {
+      case 'queued':
+      case 'in_progress':
+      case 'completed':
+      case 'failed':
+      case 'cancelled':
+        return status;
+      case 'requires_action':
+      case 'cancelling':
+        return 'in_progress';
+      default:
+        return 'in_progress';
+    }
+  }
+
+  private buildResearchUpdateFromResponse(
+    snapshot: WritingDeskJobSnapshot,
+    response: any,
+  ): WritingDeskJobResearchUpdatePayload {
+    const current = snapshot.research;
+    const status = this.mapOpenAiStatus(response?.status);
+    const { actions, cursor } = this.extractResearchActions(current, response);
+    const mergedActions = this.mergeActions(current.actions, actions);
+    const progress = this.computeResearchProgress(status, current.progress, mergedActions.length);
+
+    let result = current.result;
+    if (status === 'completed') {
+      result = this.extractResearchOutput(response) ?? current.result;
+    }
+
+    const error = status === 'failed' ? this.extractResearchError(response) ?? current.error : current.error;
+    const completedAt = FINAL_RESEARCH_STATUSES.includes(status)
+      ? new Date()
+      : current.completedAt ?? null;
+
+    return {
+      phase: 'research',
+      researchStatus: status,
+      researchProgress: this.clampProgress(progress),
+      researchActions: mergedActions,
+      researchResult: result ?? null,
+      researchResponseId: current.responseId,
+      researchError: error ?? null,
+      researchStartedAt: current.startedAt ?? new Date(),
+      researchCompletedAt: completedAt,
+      researchBilledCredits: current.billedCredits,
+      researchCursor: cursor,
+    };
+  }
+
+  private extractResearchActions(
+    current: WritingDeskJobResearchSnapshot,
+    response: any,
+  ): { actions: WritingDeskResearchActionSnapshot[]; cursor: number } {
+    const output = Array.isArray(response?.output) ? response.output : [];
+    const startIndex = Math.max(0, current.cursor);
+    const newItems = output.slice(startIndex);
+    const now = new Date();
+
+    const actions = newItems.flatMap((item: any) => this.convertOutputItemToActions(item, now));
+    const cursor = output.length;
+    return { actions, cursor };
+  }
+
+  private convertOutputItemToActions(item: any, fallbackDate: Date): WritingDeskResearchActionSnapshot[] {
+    if (!item || typeof item !== 'object') return [];
+    const baseCreatedAt = typeof item.created_at === 'number'
+      ? new Date(item.created_at * 1000)
+      : item.created_at instanceof Date
+        ? item.created_at
+        : fallbackDate;
+
+    const id = typeof item.id === 'string' && item.id.trim().length > 0 ? item.id : randomUUID();
+    const actions: WritingDeskResearchActionSnapshot[] = [];
+
+    if (item.type === 'web_search_call') {
+      const actionType = item?.action?.type ?? 'search';
+      const query = item?.action?.query;
+      const url = item?.action?.url ?? item?.action?.link;
+      let message = 'Web search in progress';
+      if (actionType === 'search' && typeof query === 'string') {
+        message = `Searching web for "${query}"`;
+      } else if (actionType === 'open_page' && typeof url === 'string') {
+        message = `Opening source ${url}`;
+      } else if (actionType === 'find_in_page' && typeof query === 'string') {
+        message = `Scanning page for "${query}"`;
+      }
+      actions.push({ id, type: 'web_search', message, createdAt: baseCreatedAt });
+    } else if (item.type === 'file_search_call') {
+      const query = item?.action?.query;
+      const message = typeof query === 'string'
+        ? `Searching reference files for "${query}"`
+        : 'Reviewing internal reference files';
+      actions.push({ id, type: 'file_search', message, createdAt: baseCreatedAt });
+    } else if (item.type === 'code_interpreter_call') {
+      const message = 'Analysing findings with code interpreter';
+      actions.push({ id, type: 'code_interpreter', message, createdAt: baseCreatedAt });
+    }
+
+    return actions;
+  }
+
+  private mergeActions(
+    current: WritingDeskResearchActionSnapshot[],
+    additional: WritingDeskResearchActionSnapshot[],
+  ): WritingDeskResearchActionSnapshot[] {
+    if (additional.length === 0) return current.slice(0);
+    const existingById = new Map(current.map((action) => [action.id, action] as const));
+    const merged = [...current];
+    for (const action of additional) {
+      if (!existingById.has(action.id)) {
+        merged.push(action);
+        existingById.set(action.id, action);
+      }
+    }
+    return merged.slice(-MAX_RESEARCH_ACTIONS);
+  }
+
+  private computeResearchProgress(
+    status: WritingDeskResearchStatus,
+    currentProgress: number,
+    actionCount: number,
+  ): number {
+    if (FINAL_RESEARCH_STATUSES.includes(status)) {
+      return 100;
+    }
+    if (status === 'queued') {
+      return Math.max(currentProgress, 5);
+    }
+    const base = Math.max(currentProgress, 10);
+    const incremental = Math.min(95, base + actionCount * 8);
+    return incremental;
+  }
+
+  private extractResearchOutput(response: any): string | null {
+    if (!response) return null;
+    if (typeof response.output_text === 'string' && response.output_text.trim().length > 0) {
+      return response.output_text;
+    }
+    const steps = Array.isArray(response?.output) ? response.output : [];
+    for (const step of steps) {
+      const contents = Array.isArray(step?.content) ? step.content : [];
+      for (const content of contents) {
+        if (typeof content?.text === 'string' && content.text.trim().length > 0) {
+          return content.text;
+        }
+        if (content?.type === 'output_text' && typeof content?.content === 'string') {
+          return content.content;
+        }
+      }
+    }
+    return null;
+  }
+
+  private extractResearchError(response: any): string | null {
+    if (!response) return null;
+    const message = response?.last_error?.message ?? response?.error?.message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+    return null;
+  }
+
+  private buildStubResearch(snapshot: WritingDeskJobSnapshot): string {
+    return `DEV-STUB RESEARCH\n\nIssue summary:\n${snapshot.form.issueDetail}\n\nPotential avenues:\n- Highlight the impact on affected parties: ${snapshot.form.affectedDetail}\n- Reference any previous actions or background: ${snapshot.form.backgroundDetail}\n- Desired outcome: ${snapshot.form.desiredOutcome}\n\nFollow-up answers:\n${snapshot.followUpQuestions
+      .map((question, idx) => `Q${idx + 1}: ${question}\nA${idx + 1}: ${snapshot.followUpAnswers[idx] ?? ''}`)
+      .join('\n')}`;
+  }
+
+  private async refundCredits(userId: string, amount: number) {
+    try {
+      await this.userCredits.addToMine(userId, amount);
+    } catch (err) {
+      this.logger.error(`Failed to refund credits for user ${userId}: ${(err as Error).message}`);
+    }
   }
 
   private isUuid(value: string) {

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
@@ -1,6 +1,30 @@
-export const WRITING_DESK_JOB_PHASES = ['initial', 'generating', 'followup', 'summary'] as const;
+export const WRITING_DESK_JOB_PHASES = ['initial', 'generating', 'followup', 'summary', 'research'] as const;
 
 export type WritingDeskJobPhase = (typeof WRITING_DESK_JOB_PHASES)[number];
+
+export const WRITING_DESK_RESEARCH_STATUSES = ['idle', 'queued', 'in_progress', 'completed', 'failed', 'cancelled'] as const;
+
+export type WritingDeskResearchStatus = (typeof WRITING_DESK_RESEARCH_STATUSES)[number];
+
+export interface WritingDeskResearchActionSnapshot {
+  id: string;
+  type: string;
+  message: string;
+  createdAt: Date;
+}
+
+export interface WritingDeskJobResearchSnapshot {
+  status: WritingDeskResearchStatus;
+  progress: number;
+  actions: WritingDeskResearchActionSnapshot[];
+  result: string | null;
+  responseId: string | null;
+  error: string | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  billedCredits: number | null;
+  cursor: number;
+}
 
 export interface WritingDeskJobFormSnapshot {
   issueDetail: string;
@@ -20,6 +44,7 @@ export interface WritingDeskJobSnapshot {
   followUpAnswers: string[];
   notes: string | null;
   responseId: string | null;
+  research: WritingDeskJobResearchSnapshot;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -37,6 +62,16 @@ export interface WritingDeskJobRecord {
   followUpAnswers?: string[];
   notes: string | null;
   responseId: string | null;
+  researchStatus?: WritingDeskResearchStatus;
+  researchProgress?: number;
+  researchActions?: WritingDeskResearchActionSnapshot[];
+  researchResult?: string | null;
+  researchResponseId?: string | null;
+  researchError?: string | null;
+  researchStartedAt?: Date | null;
+  researchCompletedAt?: Date | null;
+  researchBilledCredits?: number | null;
+  researchCursor?: number | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -51,6 +86,58 @@ export interface ActiveWritingDeskJobResource {
   followUpAnswers: string[];
   notes: string | null;
   responseId: string | null;
+  research: {
+    status: WritingDeskResearchStatus;
+    progress: number;
+    actions: Array<{
+      id: string;
+      type: string;
+      message: string;
+      createdAt: string;
+    }>;
+    result: string | null;
+    responseId: string | null;
+    error: string | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    billedCredits: number | null;
+  };
   createdAt: string;
   updatedAt: string;
+}
+
+export interface WritingDeskJobPersistencePayload {
+  jobId: string;
+  phase: WritingDeskJobPhase;
+  stepIndex: number;
+  followUpIndex: number;
+  followUpQuestions: string[];
+  formCiphertext: string;
+  followUpAnswersCiphertext: string;
+  notes: string | null;
+  responseId: string | null;
+  researchStatus: WritingDeskResearchStatus;
+  researchProgress: number;
+  researchActions: WritingDeskResearchActionSnapshot[];
+  researchResult: string | null;
+  researchResponseId: string | null;
+  researchError: string | null;
+  researchStartedAt: Date | null;
+  researchCompletedAt: Date | null;
+  researchBilledCredits: number | null;
+  researchCursor: number;
+}
+
+export interface WritingDeskJobResearchUpdatePayload {
+  phase: WritingDeskJobPhase;
+  researchStatus: WritingDeskResearchStatus;
+  researchProgress: number;
+  researchActions: WritingDeskResearchActionSnapshot[];
+  researchResult: string | null;
+  researchResponseId: string | null;
+  researchError: string | null;
+  researchStartedAt: Date | null;
+  researchCompletedAt: Date | null;
+  researchBilledCredits: number | null;
+  researchCursor: number;
 }

--- a/frontend/src/app/writingDesk/WritingDeskClient.test.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.test.tsx
@@ -35,6 +35,7 @@ describe('WritingDeskClient', () => {
   const originalFetch = global.fetch;
   const saveJobMock = jest.fn();
   const clearJobMock = jest.fn();
+  const refetchMock = jest.fn();
   const followUpQueue: FollowUpResponse[] = [];
   let fetchMock: jest.Mock<Promise<ResponseLike>, FetchArgs>;
 
@@ -102,11 +103,13 @@ describe('WritingDeskClient', () => {
   beforeEach(() => {
     saveJobMock.mockResolvedValue({ jobId: 'job-123' });
     clearJobMock.mockResolvedValue(undefined);
+    refetchMock.mockResolvedValue({ data: null } as any);
     followUpQueue.length = 0;
     setupFetchMock();
     mockUseActiveWritingDeskJob.mockReturnValue({
       activeJob: null,
       isLoading: false,
+      refetch: refetchMock as any,
       saveJob: saveJobMock,
       isSaving: false,
       clearJob: clearJobMock,

--- a/frontend/src/features/writing-desk/api/research.ts
+++ b/frontend/src/features/writing-desk/api/research.ts
@@ -1,0 +1,44 @@
+import { ActiveWritingDeskJob } from '../types';
+
+interface StartResearchResponse {
+  job: ActiveWritingDeskJob;
+  remainingCredits: number | null;
+}
+
+export async function startWritingDeskResearch(): Promise<StartResearchResponse> {
+  const res = await fetch('/api/writing-desk/jobs/active/research/start', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Request failed (${res.status})`);
+  }
+
+  const data = (await res.json().catch(() => null)) as StartResearchResponse | null;
+  if (!data || !data.job) {
+    throw new Error('Unexpected response when starting research');
+  }
+  return data;
+}
+
+export async function fetchWritingDeskResearchStatus(): Promise<ActiveWritingDeskJob> {
+  const res = await fetch('/api/writing-desk/jobs/active/research/status', {
+    method: 'GET',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Request failed (${res.status})`);
+  }
+
+  const data = (await res.json().catch(() => null)) as ActiveWritingDeskJob | null;
+  if (!data) {
+    throw new Error('Unexpected response when polling research');
+  }
+  return data;
+}

--- a/frontend/src/features/writing-desk/components/ResearchActivityFeed.tsx
+++ b/frontend/src/features/writing-desk/components/ResearchActivityFeed.tsx
@@ -1,0 +1,58 @@
+import { FC, useMemo } from 'react';
+import { WritingDeskResearchAction } from '../types';
+
+interface ResearchActivityFeedProps {
+  actions: WritingDeskResearchAction[];
+}
+
+const ResearchActivityFeed: FC<ResearchActivityFeedProps> = ({ actions }) => {
+  const items = useMemo(() => {
+    return [...actions]
+      .filter((action) => action.message?.trim?.())
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 5);
+  }, [actions]);
+
+  const formatTime = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      return '';
+    }
+  };
+
+  if (items.length === 0) {
+    return (
+      <div>
+        <h4 className="section-title" style={{ fontSize: '1rem', marginBottom: 8 }}>Latest research activity</h4>
+        <p style={{ margin: 0, color: '#4b5563' }}>Waiting for the research agent to report back…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h4 className="section-title" style={{ fontSize: '1rem', marginBottom: 8 }}>Latest research activity</h4>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {items.map((action) => (
+          <li
+            key={action.id}
+            style={{
+              padding: '8px 0',
+              borderBottom: '1px solid #e5e7eb',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              gap: 12,
+            }}
+          >
+            <span style={{ flex: 1 }}>{action.message}</span>
+            <span style={{ fontSize: '0.75rem', color: '#6b7280', whiteSpace: 'nowrap' }}>{formatTime(action.createdAt)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ResearchActivityFeed;

--- a/frontend/src/features/writing-desk/components/ResearchProgressBar.tsx
+++ b/frontend/src/features/writing-desk/components/ResearchProgressBar.tsx
@@ -1,0 +1,55 @@
+import { FC, useMemo } from 'react';
+import { WritingDeskResearchStatus } from '../types';
+
+interface ResearchProgressBarProps {
+  progress: number;
+  status: WritingDeskResearchStatus;
+}
+
+const STATUS_LABELS: Record<WritingDeskResearchStatus, string> = {
+  idle: 'Waiting to start',
+  queued: 'Queued with OpenAI',
+  in_progress: 'Research underway',
+  completed: 'Research complete',
+  failed: 'Research failed',
+  cancelled: 'Research cancelled',
+};
+
+const ResearchProgressBar: FC<ResearchProgressBarProps> = ({ progress, status }) => {
+  const clamped = useMemo(() => {
+    if (!Number.isFinite(progress)) return 0;
+    if (progress < 0) return 0;
+    if (progress > 100) return 100;
+    return Math.round(progress);
+  }, [progress]);
+
+  const statusLabel = STATUS_LABELS[status] ?? 'Research status';
+  const ariaLabel = `${statusLabel} (${clamped}% complete)`;
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span style={{ fontWeight: 600 }}>{statusLabel}</span>
+        <span style={{ fontSize: '0.9rem', color: '#4b5563' }}>{clamped}%</span>
+      </div>
+      <div style={{ marginTop: 8, height: 8, background: '#e5e7eb', borderRadius: 999 }}>
+        <div
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={clamped}
+          aria-label={ariaLabel}
+          style={{
+            width: `${clamped}%`,
+            height: '100%',
+            background: status === 'failed' ? '#b91c1c' : status === 'completed' ? '#16a34a' : '#2563eb',
+            borderRadius: 999,
+            transition: 'width 0.4s ease',
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ResearchProgressBar;

--- a/frontend/src/features/writing-desk/types.ts
+++ b/frontend/src/features/writing-desk/types.ts
@@ -1,6 +1,29 @@
-export const WRITING_DESK_JOB_PHASES = ['initial', 'generating', 'followup', 'summary'] as const;
+export const WRITING_DESK_JOB_PHASES = ['initial', 'generating', 'followup', 'summary', 'research'] as const;
 
 export type WritingDeskJobPhase = (typeof WRITING_DESK_JOB_PHASES)[number];
+
+export const WRITING_DESK_RESEARCH_STATUSES = ['idle', 'queued', 'in_progress', 'completed', 'failed', 'cancelled'] as const;
+
+export type WritingDeskResearchStatus = (typeof WRITING_DESK_RESEARCH_STATUSES)[number];
+
+export interface WritingDeskResearchAction {
+  id: string;
+  type: string;
+  message: string;
+  createdAt: string;
+}
+
+export interface WritingDeskResearchState {
+  status: WritingDeskResearchStatus;
+  progress: number;
+  actions: WritingDeskResearchAction[];
+  result: string | null;
+  responseId: string | null;
+  error: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  billedCredits: number | null;
+}
 
 export interface WritingDeskJobFormSnapshot {
   issueDetail: string;
@@ -19,6 +42,7 @@ export interface ActiveWritingDeskJob {
   followUpAnswers: string[];
   notes: string | null;
   responseId: string | null;
+  research: WritingDeskResearchState;
   createdAt: string;
   updatedAt: string;
 }
@@ -33,4 +57,5 @@ export interface UpsertActiveWritingDeskJobPayload {
   followUpAnswers: string[];
   notes?: string | null;
   responseId?: string | null;
+  research?: WritingDeskResearchState;
 }


### PR DESCRIPTION
## Summary
- extend writing desk job schema and types to store research metadata and credit usage
- integrate OpenAI deep research background calls with new start/status endpoints and repository updates
- add frontend polling, components, and API helpers to show research progress, activity, and raw findings

## Testing
- npx tsc -p frontend/tsconfig.json --noEmit
- npx tsc -p backend-api/tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d8299653908321aa7289287554d47c