### PR TITLE
Simplify writing desk intake flow

### DIFF
--- a/backend-api/src/ai/dto/writing-desk-follow-up.dto.ts
+++ b/backend-api/src/ai/dto/writing-desk-follow-up.dto.ts
@@ -3,31 +3,16 @@ import { ArrayMaxSize, IsArray, IsNotEmpty, IsOptional, IsString, MaxLength } fr
 export class WritingDeskFollowUpDto {
   @IsString()
   @IsNotEmpty()
-  @MaxLength(2000)
-  issueDetail!: string;
-
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(1200)
-  affectedDetail!: string;
-
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(2000)
-  backgroundDetail!: string;
-
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(1200)
-  desiredOutcome!: string;
+  @MaxLength(4000)
+  issueDescription!: string;
 
   @IsArray()
-  @ArrayMaxSize(3)
+  @ArrayMaxSize(5)
   @IsString({ each: true })
   followUpQuestions!: string[];
 
   @IsArray()
-  @ArrayMaxSize(3)
+  @ArrayMaxSize(5)
   @IsString({ each: true })
   followUpAnswers!: string[];
 

--- a/backend-api/src/ai/dto/writing-desk-intake.dto.ts
+++ b/backend-api/src/ai/dto/writing-desk-intake.dto.ts
@@ -3,22 +3,7 @@ import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 export class WritingDeskIntakeDto {
   @IsString()
   @IsNotEmpty()
-  @MaxLength(2000)
-  issueDetail!: string;
-
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(1200)
-  affectedDetail!: string;
-
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(2000)
-  backgroundDetail!: string;
-
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(1200)
-  desiredOutcome!: string;
+  @MaxLength(4000)
+  issueDescription!: string;
 }
 

--- a/backend-api/src/writing-desk-jobs/dto/upsert-active-writing-desk-job.dto.ts
+++ b/backend-api/src/writing-desk-jobs/dto/upsert-active-writing-desk-job.dto.ts
@@ -19,16 +19,7 @@ import {
 
 class WritingDeskJobFormDto {
   @IsString()
-  issueDetail!: string;
-
-  @IsString()
-  affectedDetail!: string;
-
-  @IsString()
-  backgroundDetail!: string;
-
-  @IsString()
-  desiredOutcome!: string;
+  issueDescription!: string;
 }
 
 export class UpsertActiveWritingDeskJobDto {

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.service.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.service.ts
@@ -81,10 +81,7 @@ export class WritingDeskJobsService {
     };
 
     const form: WritingDeskJobFormSnapshot = {
-      issueDetail: trim(input.form?.issueDetail),
-      affectedDetail: trim(input.form?.affectedDetail),
-      backgroundDetail: trim(input.form?.backgroundDetail),
-      desiredOutcome: trim(input.form?.desiredOutcome),
+      issueDescription: trim(input.form?.issueDescription),
     };
 
     const followUpQuestions = Array.isArray(input.followUpQuestions)
@@ -162,19 +159,29 @@ export class WritingDeskJobsService {
     }
 
     if (record.form) {
+      if (typeof (record.form as any)?.issueDescription === 'string') {
+        return {
+          issueDescription: (record.form as any).issueDescription ?? '',
+        };
+      }
+
+      const legacyIssue = [
+        record.form.issueDetail ?? '',
+        record.form.affectedDetail ?? '',
+        record.form.backgroundDetail ?? '',
+        record.form.desiredOutcome ?? '',
+      ]
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+        .join('\n\n');
+
       return {
-        issueDetail: record.form.issueDetail ?? '',
-        affectedDetail: record.form.affectedDetail ?? '',
-        backgroundDetail: record.form.backgroundDetail ?? '',
-        desiredOutcome: record.form.desiredOutcome ?? '',
+        issueDescription: legacyIssue,
       };
     }
 
     return {
-      issueDetail: '',
-      affectedDetail: '',
-      backgroundDetail: '',
-      desiredOutcome: '',
+      issueDescription: '',
     };
   }
 

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
@@ -7,10 +7,7 @@ export const WRITING_DESK_RESEARCH_STATUSES = ['idle', 'running', 'completed', '
 export type WritingDeskResearchStatus = (typeof WRITING_DESK_RESEARCH_STATUSES)[number];
 
 export interface WritingDeskJobFormSnapshot {
-  issueDetail: string;
-  affectedDetail: string;
-  backgroundDetail: string;
-  desiredOutcome: string;
+  issueDescription: string;
 }
 
 export interface WritingDeskJobSnapshot {
@@ -40,7 +37,12 @@ export interface WritingDeskJobRecord {
   followUpQuestions: string[];
   formCiphertext?: string;
   followUpAnswersCiphertext?: string;
-  form?: WritingDeskJobFormSnapshot;
+  form?: WritingDeskJobFormSnapshot & {
+    issueDetail?: string;
+    affectedDetail?: string;
+    backgroundDetail?: string;
+    desiredOutcome?: string;
+  };
   followUpAnswers?: string[];
   notes: string | null;
   responseId: string | null;

--- a/frontend/src/app/writingDesk/WritingDeskClient.test.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.test.tsx
@@ -76,22 +76,11 @@ describe('WritingDeskClient', () => {
   };
 
   const answerInitialQuestions = async () => {
-    const steps = [
-      { label: 'Describe the issue in detail', answer: 'Issue description' },
-      { label: 'Tell me who is affected and how', answer: 'Everyone is affected' },
-      { label: 'Other supporting background', answer: 'Background context' },
-      { label: 'What do you want to happen?', answer: 'Desired outcome' },
-    ];
-
-    for (let idx = 0; idx < steps.length; idx += 1) {
-      const step = steps[idx];
-      const textarea = await screen.findByLabelText(step.label);
-      fireEvent.change(textarea, { target: { value: step.answer } });
-      const buttonLabel = idx === steps.length - 1 ? 'Generate follow-up questions' : 'Next';
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: buttonLabel }));
-      });
-    }
+    const textarea = await screen.findByLabelText('Describe your issue in as much detail as you can');
+    fireEvent.change(textarea, { target: { value: 'Issue description' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Generate follow-up questions' }));
+    });
   };
 
   const answerFollowUpQuestions = async (answers: string[]) => {
@@ -217,7 +206,7 @@ describe('WritingDeskClient', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Yes, edit intake' }));
     });
 
-    await screen.findByLabelText('Describe the issue in detail');
+    await screen.findByLabelText('Describe your issue in as much detail as you can');
 
     await answerInitialQuestions();
 

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -8,7 +8,7 @@ import StartOverConfirmModal from '../../features/writing-desk/components/StartO
 import { useActiveWritingDeskJob } from '../../features/writing-desk/hooks/useActiveWritingDeskJob';
 import { ActiveWritingDeskJob, UpsertActiveWritingDeskJobPayload } from '../../features/writing-desk/types';
 
-type StepKey = 'issueDetail' | 'affectedDetail' | 'backgroundDetail' | 'desiredOutcome';
+type StepKey = 'issueDescription';
 
 type FormState = Record<StepKey, string>;
 
@@ -19,36 +19,17 @@ const steps: Array<{
   placeholder: string;
 }> = [
   {
-    key: 'issueDetail',
-    title: 'Describe the issue in detail',
-    description: 'Explain the situation as clearly as you can so the letter can state the facts.',
-    placeholder: 'E.g. The heating in my flat has been broken since December and…',
-  },
-  {
-    key: 'affectedDetail',
-    title: 'Tell me who is affected and how',
-    description: 'Share who is impacted – you, your family, neighbours, or the wider community.',
-    placeholder: 'E.g. My young children are getting ill from the cold and elderly neighbours are…',
-  },
-  {
-    key: 'backgroundDetail',
-    title: 'Other supporting background',
-    description: 'Mention any history, evidence, or previous actions taken so far.',
-    placeholder: 'E.g. I have reported this to the council twice (ref 12345) and attached photos…',
-  },
-  {
-    key: 'desiredOutcome',
-    title: 'What do you want to happen?',
-    description: 'State the outcome you hope to achieve so the MP knows what to push for.',
-    placeholder: 'E.g. I want the housing association to replace the boiler within two weeks…',
+    key: 'issueDescription',
+    title: 'Describe your issue in as much detail as you can',
+    description:
+      'Share the full story, including who is affected, what has happened so far, and what you hope your MP can help achieve.',
+    placeholder:
+      'E.g. The heating in my flat has been broken since December. My children are getting sick, I have reported it twice, and I need the housing association to replace the boiler within two weeks…',
   },
 ];
 
 const initialFormState: FormState = {
-  issueDetail: '',
-  affectedDetail: '',
-  backgroundDetail: '',
-  desiredOutcome: '',
+  issueDescription: '',
 };
 
 type ResearchStatus = 'idle' | 'running' | 'completed' | 'error';
@@ -553,10 +534,7 @@ export default function WritingDeskClient() {
     (job: ActiveWritingDeskJob) => {
       closeResearchStream();
       setForm({
-        issueDetail: job.form?.issueDetail ?? '',
-        affectedDetail: job.form?.affectedDetail ?? '',
-        backgroundDetail: job.form?.backgroundDetail ?? '',
-        desiredOutcome: job.form?.desiredOutcome ?? '',
+        issueDescription: job.form?.issueDescription ?? '',
       });
       setPhase(job.phase);
       setStepIndex(Math.max(0, job.stepIndex ?? 0));
@@ -593,10 +571,7 @@ export default function WritingDeskClient() {
       stepIndex: job.stepIndex,
       followUpIndex: job.followUpIndex,
       form: {
-        issueDetail: job.form?.issueDetail ?? '',
-        affectedDetail: job.form?.affectedDetail ?? '',
-        backgroundDetail: job.form?.backgroundDetail ?? '',
-        desiredOutcome: job.form?.desiredOutcome ?? '',
+        issueDescription: job.form?.issueDescription ?? '',
       },
       followUpQuestions: Array.isArray(job.followUpQuestions) ? [...job.followUpQuestions] : [],
       followUpAnswers: Array.isArray(job.followUpAnswers) ? [...job.followUpAnswers] : [],
@@ -753,10 +728,7 @@ export default function WritingDeskClient() {
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
-          issueDetail: form.issueDetail.trim(),
-          affectedDetail: form.affectedDetail.trim(),
-          backgroundDetail: form.backgroundDetail.trim(),
-          desiredOutcome: form.desiredOutcome.trim(),
+          issueDescription: form.issueDescription.trim(),
           followUpQuestions: questions,
           followUpAnswers: answers.map((answer) => answer.trim()),
           notes: (context?.notes ?? notes) ?? undefined,
@@ -843,10 +815,7 @@ export default function WritingDeskClient() {
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
           body: JSON.stringify({
-            issueDetail: form.issueDetail.trim(),
-            affectedDetail: form.affectedDetail.trim(),
-            backgroundDetail: form.backgroundDetail.trim(),
-            desiredOutcome: form.desiredOutcome.trim(),
+            issueDescription: form.issueDescription.trim(),
           }),
         });
         if (!res.ok) {
@@ -1004,7 +973,7 @@ export default function WritingDeskClient() {
   const handleConfirmEditIntake = useCallback(() => {
     resetFollowUps();
     setEditIntakeModalOpen(false);
-    handleEditInitialStep('issueDetail');
+    handleEditInitialStep('issueDescription');
   }, [handleEditInitialStep, resetFollowUps]);
 
   const handleCancelEditIntake = useCallback(() => {
@@ -1354,7 +1323,7 @@ export default function WritingDeskClient() {
                 onClick={() => setShowSummaryDetails((prev) => !prev)}
                 disabled={loading}
               >
-                {showSummaryDetails ? 'Hide previous steps' : 'Show previous steps'}
+                {showSummaryDetails ? 'Hide intake details' : 'Show intake details'}
               </button>
               {responseId && !showSummaryDetails && (
                 <span style={{ fontSize: '0.85rem', color: '#6b7280' }}>Reference ID: {responseId}</span>

--- a/frontend/src/features/writing-desk/types.ts
+++ b/frontend/src/features/writing-desk/types.ts
@@ -7,10 +7,7 @@ export const WRITING_DESK_RESEARCH_STATUSES = ['idle', 'running', 'completed', '
 export type WritingDeskResearchStatus = (typeof WRITING_DESK_RESEARCH_STATUSES)[number];
 
 export interface WritingDeskJobFormSnapshot {
-  issueDetail: string;
-  affectedDetail: string;
-  backgroundDetail: string;
-  desiredOutcome: string;
+  issueDescription: string;
 }
 
 export interface ActiveWritingDeskJob {


### PR DESCRIPTION
## Summary
- replace the multi-question intake flow with a single detailed issue prompt in the writing desk UI and tests
- update shared writing desk types to use a consolidated `issueDescription` field and support up to five follow-up questions
- align backend DTOs and AI follow-up generation logic with the new intake structure and expanded question limit

## Testing
- npx nx test frontend --testNamePattern=WritingDeskClient *(terminal session crashed during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68d9920f3bb48321b6fa774e10854459