### PR TITLE
Adjust research session actions in writing desk

### DIFF
--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -190,6 +190,7 @@ export default function WritingDeskClient() {
   const currentStep = phase === 'initial' ? steps[stepIndex] ?? null : null;
   const followUpCreditCost = 0.1;
   const deepResearchCreditCost = 0.7;
+  const letterCreditCost = 0.2;
   const formatCredits = (value: number) => {
     const rounded = Math.round(value * 100) / 100;
     return rounded.toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');
@@ -1418,7 +1419,7 @@ export default function WritingDeskClient() {
                 type="button"
                 className="btn-secondary"
                 onClick={() => setEditIntakeModalOpen(true)}
-                disabled={loading}
+                disabled={loading || researchStatus === 'running'}
               >
                 Edit intake answers
               </button>
@@ -1427,19 +1428,51 @@ export default function WritingDeskClient() {
                   type="button"
                   className="btn-secondary"
                   onClick={() => handleEditFollowUpQuestion(0)}
-                  disabled={loading}
+                  disabled={loading || researchStatus === 'running'}
                 >
                   Review follow-up answers
                 </button>
               )}
-              <button type="button" className="btn-primary" disabled={loading}>
-                Create my letter
-              </button>
+              {researchStatus === 'completed' && (
+                <button
+                  type="button"
+                  className="btn-primary create-letter-button"
+                  disabled={loading}
+                >
+                  Create my letter (costs {formatCredits(letterCreditCost)} credits)
+                </button>
+              )}
             </div>
           </div>
         )}
       </div>
       </section>
+      <style jsx>{`
+        @keyframes create-letter-jiggle {
+          0%, 100% {
+            transform: translateX(0);
+          }
+          15% {
+            transform: translateX(-2px) rotate(-1deg);
+          }
+          30% {
+            transform: translateX(2px) rotate(1deg);
+          }
+          45% {
+            transform: translateX(-2px) rotate(-1deg);
+          }
+          60% {
+            transform: translateX(2px) rotate(1deg);
+          }
+          75% {
+            transform: translateX(-1px) rotate(-0.5deg);
+          }
+        }
+
+        .create-letter-button {
+          animation: create-letter-jiggle 1.6s ease-in-out infinite;
+        }
+      `}</style>
     </>
   );
 }

--- a/frontend/src/features/writing-desk/components/StartOverConfirmModal.tsx
+++ b/frontend/src/features/writing-desk/components/StartOverConfirmModal.tsx
@@ -37,8 +37,9 @@ export default function StartOverConfirmModal({ open, onConfirm, onCancel }: Sta
           Start over?
         </h2>
         <p style={{ marginBottom: 16, color: '#334155', lineHeight: 1.6 }}>
-          Starting over will erase your current answers, follow-up questions, and any saved progress for
-          this letter.
+          <strong style={{ color: '#b91c1c' }}>Warning:</strong> Starting over will erase your current answers, follow-up
+          questions, and any saved progress for this letter. You will also forfeit any credits already spent on this
+          session.
         </p>
         <p style={{ marginBottom: 20, color: '#475569' }}>Do you want to begin again?</p>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>


### PR DESCRIPTION
## Summary
- disable intake and follow-up editing while research is running
- gate the letter creation button behind completed research and add animated credit messaging
- clarify the start over confirmation with a warning about lost progress and credits

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabd883e5c8321bb1ee1a433df296f