### PR TITLE
Refine letter composition flow

### DIFF
--- a/backend-api/src/ai/ai.controller.ts
+++ b/backend-api/src/ai/ai.controller.ts
@@ -31,4 +31,10 @@ export class AiController {
     const userId = req?.user?.id ?? req?.user?._id ?? null;
     return this.ai.streamWritingDeskDeepResearch(userId, { jobId: jobId ?? null });
   }
+
+  @Sse('writing-desk/letter')
+  writingDeskLetter(@Req() req: any, @Query('jobId') jobId?: string, @Query('tone') tone?: string) {
+    const userId = req?.user?.id ?? req?.user?._id ?? null;
+    return this.ai.streamWritingDeskLetter(userId, { jobId: jobId ?? null, tone: tone ?? null });
+  }
 }

--- a/backend-api/src/ai/ai.module.ts
+++ b/backend-api/src/ai/ai.module.ts
@@ -5,9 +5,18 @@ import { WritingDeskJobsModule } from '../writing-desk-jobs/writing-desk-jobs.mo
 import { UserMpModule } from '../user-mp/user-mp.module';
 import { AiService } from './ai.service';
 import { AiController } from './ai.controller';
+import { UsersModule } from '../users/users.module';
+import { UserAddressModule } from '../user-address-store/user-address.module';
 
 @Module({
-  imports: [ConfigModule, UserCreditsModule, forwardRef(() => WritingDeskJobsModule), UserMpModule],
+  imports: [
+    ConfigModule,
+    UserCreditsModule,
+    forwardRef(() => WritingDeskJobsModule),
+    UserMpModule,
+    UsersModule,
+    UserAddressModule,
+  ],
   controllers: [AiController],
   providers: [AiService],
   exports: [AiService],

--- a/backend-api/src/ai/ai.service.ts
+++ b/backend-api/src/ai/ai.service.ts
@@ -5,13 +5,22 @@ import { WritingDeskFollowUpDto } from './dto/writing-desk-follow-up.dto';
 import { UserCreditsService } from '../user-credits/user-credits.service';
 import { WritingDeskJobsService } from '../writing-desk-jobs/writing-desk-jobs.service';
 import { UserMpService } from '../user-mp/user-mp.service';
-import { ActiveWritingDeskJobResource, WritingDeskResearchStatus } from '../writing-desk-jobs/writing-desk-jobs.types';
+import { UsersService } from '../users/users.service';
+import { UserAddressService } from '../user-address-store/user-address.service';
+import {
+  ActiveWritingDeskJobResource,
+  WritingDeskLetterStatus,
+  WritingDeskLetterTone,
+  WritingDeskResearchStatus,
+  WRITING_DESK_LETTER_TONES,
+} from '../writing-desk-jobs/writing-desk-jobs.types';
 import { UpsertActiveWritingDeskJobDto } from '../writing-desk-jobs/dto/upsert-active-writing-desk-job.dto';
 import { Observable, ReplaySubject, Subscription } from 'rxjs';
 import type { ResponseStreamEvent } from 'openai/resources/responses/responses';
 
 const FOLLOW_UP_CREDIT_COST = 0.1;
 const DEEP_RESEARCH_CREDIT_COST = 0.7;
+const LETTER_CREDIT_COST = 0.2;
 
 type DeepResearchRequestExtras = {
   tools?: Array<Record<string, unknown>>;
@@ -58,6 +67,238 @@ const DEEP_RESEARCH_RUN_TTL_MS = 5 * 60 * 1000;
 const BACKGROUND_POLL_INTERVAL_MS = 2000;
 const BACKGROUND_POLL_TIMEOUT_MS = 20 * 60 * 1000;
 
+type LetterStreamPayload =
+  | { type: 'status'; status: string; remainingCredits?: number | null }
+  | { type: 'event'; event: Record<string, unknown> }
+  | { type: 'delta'; text: string }
+  | { type: 'letter_delta'; html: string }
+  | {
+      type: 'complete';
+      letter: LetterCompletePayload;
+      remainingCredits: number | null;
+    }
+  | { type: 'error'; message: string; remainingCredits?: number | null };
+
+interface WritingDeskLetterResult {
+  mp_name: string;
+  mp_address_1: string;
+  mp_address_2: string;
+  mp_city: string;
+  mp_county: string;
+  mp_postcode: string;
+  date: string;
+  letter_content: string;
+  sender_name: string;
+  sender_address_1: string;
+  sender_address_2: string;
+  sender_address_3: string;
+  sender_city: string;
+  sender_county: string;
+  sender_postcode: string;
+  references: string[];
+}
+
+interface LetterCompletePayload {
+  mpName: string;
+  mpAddress1: string;
+  mpAddress2: string;
+  mpCity: string;
+  mpCounty: string;
+  mpPostcode: string;
+  date: string;
+  letterContent: string;
+  senderName: string;
+  senderAddress1: string;
+  senderAddress2: string;
+  senderAddress3: string;
+  senderCity: string;
+  senderCounty: string;
+  senderPostcode: string;
+  references: string[];
+  responseId: string | null;
+  tone: WritingDeskLetterTone;
+  rawJson: string;
+}
+
+interface LetterContext {
+  mpName: string;
+  mpAddress1: string;
+  mpAddress2: string;
+  mpCity: string;
+  mpCounty: string;
+  mpPostcode: string;
+  constituency: string;
+  senderName: string;
+  senderAddress1: string;
+  senderAddress2: string;
+  senderAddress3: string;
+  senderCity: string;
+  senderCounty: string;
+  senderPostcode: string;
+  today: string;
+}
+
+const LETTER_RESPONSE_SCHEMA = {
+  type: 'object',
+  properties: {
+    mp_name: {
+      type: 'string',
+      description: "Full name of the Member of Parliament.",
+    },
+    mp_address_1: {
+      type: 'string',
+      description: "First line of the MP's address.",
+    },
+    mp_address_2: {
+      type: 'string',
+      description: "Second line of the MP's address.",
+    },
+    mp_city: {
+      type: 'string',
+      description: "City of the MP's address.",
+    },
+    mp_county: {
+      type: 'string',
+      description: "County of the MP's address.",
+    },
+    mp_postcode: {
+      type: 'string',
+      description: "Post code of the MP's address.",
+    },
+    date: {
+      type: 'string',
+      description: 'Date the letter is written (ISO 8601 format recommended).',
+      pattern: '^\\d{4}-\\d{2}-\\d{2}$',
+    },
+    letter_content: {
+      type: 'string',
+      description: 'The text body of the letter.',
+    },
+    sender_name: {
+      type: 'string',
+      description: 'Name of the person sending the letter.',
+    },
+    sender_address_1: {
+      type: 'string',
+      description: "First line of the sender's address.",
+    },
+    sender_address_2: {
+      type: 'string',
+      description: "Second line of the sender's address.",
+    },
+    sender_address_3: {
+      type: 'string',
+      description: "Third line of the sender's address.",
+    },
+    sender_city: {
+      type: 'string',
+      description: "City of the sender's address.",
+    },
+    sender_county: {
+      type: 'string',
+      description: "County of the sender's address.",
+    },
+    sender_postcode: {
+      type: 'string',
+      description: "Post code of the sender's address.",
+    },
+    references: {
+      type: 'array',
+      description: 'List of references or citation URLs.',
+      items: {
+        type: 'string',
+        description: 'Citation or URL used as a reference in the letter.',
+      },
+    },
+  },
+  required: [
+    'mp_name',
+    'mp_address_1',
+    'mp_address_2',
+    'mp_city',
+    'mp_county',
+    'mp_postcode',
+    'date',
+    'letter_content',
+    'sender_name',
+    'sender_address_1',
+    'sender_address_2',
+    'sender_address_3',
+    'sender_city',
+    'sender_county',
+    'sender_postcode',
+    'references',
+  ],
+  additionalProperties: false,
+} as const;
+
+const LETTER_TONE_DETAILS: Record<WritingDeskLetterTone, { label: string; prompt: string }> = {
+  formal: {
+    label: 'Formal',
+    prompt:
+      'Write with formal parliamentary etiquette: respectful, precise, and structured with clear paragraphs.',
+  },
+  polite_but_firm: {
+    label: 'Polite but firm',
+    prompt:
+      'Maintain polite language while firmly emphasising the urgency and expectation of action.',
+  },
+  empathetic: {
+    label: 'Empathetic',
+    prompt:
+      'Adopt a compassionate tone that centres the human impact while remaining respectful and solution-focused.',
+  },
+  urgent: {
+    label: 'Urgent',
+    prompt:
+      'Convey urgency and seriousness without being aggressive. Keep sentences direct and compelling.',
+  },
+  neutral: {
+    label: 'Neutral',
+    prompt:
+      'Use clear, matter-of-fact language that presents evidence and requests without emotional colouring.',
+  },
+};
+
+const LETTER_TONE_SIGN_OFFS: Record<WritingDeskLetterTone, string> = {
+  formal: 'Yours faithfully,',
+  polite_but_firm: 'Yours sincerely,',
+  empathetic: 'With thanks for your understanding,',
+  urgent: 'Yours urgently,',
+  neutral: 'Yours sincerely,',
+};
+
+const LETTER_TONE_REQUEST_PREFIX: Record<WritingDeskLetterTone, string> = {
+  formal: 'I would be grateful if you could',
+  polite_but_firm: 'I need you to',
+  empathetic: 'I kindly ask that you',
+  urgent: 'Please urgently',
+  neutral: 'I ask that you',
+};
+
+const LETTER_SYSTEM_PROMPT = `You are generating a UK MP letter using stored MP and sender details plus prior user inputs.
+
+Goals:
+
+1. Return output strictly conforming to the provided JSON schema.
+2. Use stored MP profile for mp_* fields and stored sender profile for sender_*.
+3. Set date to match the schema’s regex: ^\\d{4}-\\d{2}-\\d{2}$.
+4. Put the full HTML letter in letter_content. Use semantic HTML only (<p>, <strong>, <em>, lists).
+5. Write in the tone selected by the user.
+6. Draw on all prior inputs: user_intake (issue, who is affected, background, requested action); follow_ups (clarifications); deep_research (facts, citations, URLs).
+7. Include only accurate, supportable statements. Add actual URLs used into the references array.
+8. If any stored values are missing, output an empty string for that field, but keep the schema valid.
+
+Letter content requirements:
+
+* Opening: state the issue and constituency link.
+* Body: evidence-led argument in chosen tone.
+* Ask: specific, actionable request of the MP.
+* Closing: professional and courteous.
+
+Output:
+Return only the JSON object defined by the schema. Do not output explanations or text outside the JSON.`;
+
 @Injectable()
 export class AiService {
   private readonly logger = new Logger(AiService.name);
@@ -69,6 +310,8 @@ export class AiService {
     private readonly userCredits: UserCreditsService,
     private readonly writingDeskJobs: WritingDeskJobsService,
     private readonly userMp: UserMpService,
+    private readonly users: UsersService,
+    private readonly userAddress: UserAddressService,
   ) {}
 
   private async getOpenAiClient(apiKey: string) {
@@ -296,6 +539,253 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
         subscription?.unsubscribe();
         subscription = null;
         settled = true;
+      };
+    });
+  }
+
+  streamWritingDeskLetter(
+    userId: string | null | undefined,
+    options?: { jobId?: string | null; tone?: string | null },
+  ): Observable<MessageEvent> {
+    if (!userId) {
+      throw new BadRequestException('User account required');
+    }
+
+    const tone = this.normaliseLetterTone(options?.tone ?? null);
+    if (!tone) {
+      throw new BadRequestException('Select a tone before composing the letter.');
+    }
+
+    return new Observable<MessageEvent>((subscriber) => {
+      let controller: { abort: () => void } | null = null;
+      let closed = false;
+
+      const send = (payload: LetterStreamPayload) => {
+        if (!closed && !subscriber.closed) {
+          subscriber.next({ data: JSON.stringify(payload) });
+        }
+      };
+
+      const complete = () => {
+        if (!closed && !subscriber.closed) {
+          subscriber.complete();
+        }
+        closed = true;
+      };
+
+      (async () => {
+        let deductionApplied = false;
+        let remainingCredits: number | null = null;
+        let baselineJob: ActiveWritingDeskJobResource | null = null;
+
+        try {
+          baselineJob = await this.resolveActiveWritingDeskJob(userId, options?.jobId ?? null);
+
+          const researchContent = this.normaliseResearchContent(baselineJob.researchContent ?? null);
+          if (!researchContent) {
+            throw new BadRequestException('Run deep research before composing the letter.');
+          }
+
+          const { credits: creditsAfterCharge } = await this.userCredits.deductFromMine(
+            userId,
+            LETTER_CREDIT_COST,
+          );
+          deductionApplied = true;
+          remainingCredits = Math.round(creditsAfterCharge * 100) / 100;
+
+          await this.persistLetterState(userId, baselineJob, {
+            status: 'generating',
+            tone,
+            responseId: null,
+            content: null,
+            references: [],
+            json: null,
+          });
+
+          send({ type: 'status', status: 'Composing your letter…', remainingCredits });
+
+          const apiKey = this.config.get<string>('OPENAI_API_KEY');
+          const model = this.config.get<string>('OPENAI_LETTER_MODEL')?.trim() || 'gpt-5';
+          const verbosity = this.normaliseLetterVerbosity(
+            this.config.get<string>('OPENAI_LETTER_VERBOSITY'),
+          );
+          const reasoningEffort = this.normaliseLetterReasoningEffort(
+            model,
+            this.config.get<string>('OPENAI_LETTER_REASONING_EFFORT'),
+          );
+
+          const context = await this.resolveLetterContext(userId);
+          const research = researchContent;
+          const prompt = this.buildLetterPrompt({ job: baselineJob, tone, context, research });
+
+          if (!apiKey) {
+            const stub = this.buildStubLetter({ job: baselineJob, tone, context, research });
+            const rawJson = JSON.stringify(stub);
+            await this.persistLetterResult(userId, baselineJob, {
+              status: 'completed',
+              tone,
+              responseId: 'dev-stub',
+              content: stub.letter_content,
+              references: stub.references ?? [],
+              json: rawJson,
+            });
+            send({ type: 'letter_delta', html: stub.letter_content });
+            send({
+              type: 'complete',
+              letter: this.toLetterCompletePayload(stub, {
+                responseId: 'dev-stub',
+                tone,
+                rawJson,
+              }),
+              remainingCredits,
+            });
+            complete();
+            return;
+          }
+
+          const client = await this.getOpenAiClient(apiKey);
+
+          const stream = client.responses.stream({
+            model,
+            input: [
+              { role: 'system', content: [{ type: 'input_text', text: this.buildLetterSystemPrompt() }] },
+              { role: 'user', content: [{ type: 'input_text', text: prompt }] },
+            ],
+            text: {
+              format: {
+                type: 'json_schema',
+                name: 'mp_letter',
+                strict: true,
+                schema: LETTER_RESPONSE_SCHEMA,
+              },
+              verbosity,
+            },
+            reasoning: {
+              effort: reasoningEffort,
+              summary: 'auto',
+            },
+            tools: [],
+            store: true,
+            include: ['reasoning.encrypted_content', 'web_search_call.action.sources'],
+          }) as ResponseStreamLike;
+
+          controller = stream.controller ?? null;
+
+          let jsonBuffer = '';
+
+          for await (const event of stream) {
+            const normalised = this.normaliseStreamEvent(event);
+            const eventType = typeof normalised.type === 'string' ? normalised.type : null;
+
+            if (eventType?.startsWith('response.reasoning')) {
+              send({ type: 'event', event: normalised });
+              continue;
+            }
+
+            if (eventType === 'response.output_text.delta') {
+              const delta = this.extractOutputTextDelta(normalised);
+              if (delta) {
+                jsonBuffer += delta;
+                send({ type: 'delta', text: delta });
+                const preview = this.extractLetterPreview(jsonBuffer);
+                if (preview !== null) {
+                  send({ type: 'letter_delta', html: preview });
+                }
+              }
+              continue;
+            }
+
+            if (eventType === 'response.output_text.done') {
+              const preview = this.extractLetterPreview(jsonBuffer);
+              if (preview !== null) {
+                send({ type: 'letter_delta', html: preview });
+              }
+              continue;
+            }
+
+            if (eventType === 'response.completed') {
+              const responseId = (normalised as any)?.response?.id ?? null;
+              const finalText = this.extractFirstText((normalised as any)?.response) ?? jsonBuffer;
+              const parsed = this.parseLetterResult(finalText);
+              const references = Array.isArray(parsed.references) ? parsed.references : [];
+
+              await this.persistLetterResult(userId, baselineJob, {
+                status: 'completed',
+                tone,
+                responseId,
+                content: parsed.letter_content,
+                references,
+                json: finalText,
+              });
+
+              send({
+                type: 'complete',
+                letter: this.toLetterCompletePayload(parsed, {
+                  responseId,
+                  tone,
+                  rawJson: finalText,
+                }),
+                remainingCredits,
+              });
+              complete();
+              return;
+            }
+
+            if (eventType === 'response.error' || eventType === 'response.failed') {
+              const message =
+                typeof (normalised as any)?.error?.message === 'string'
+                  ? ((normalised as any).error.message as string)
+                  : 'Letter composition failed. Please try again in a few moments.';
+              throw new Error(message);
+            }
+          }
+
+          throw new Error('Letter composition ended unexpectedly. Please try again in a few moments.');
+        } catch (error) {
+          if (deductionApplied) {
+            await this.refundCredits(userId, LETTER_CREDIT_COST);
+            if (typeof remainingCredits === 'number') {
+              remainingCredits = Math.round((remainingCredits + LETTER_CREDIT_COST) * 100) / 100;
+            }
+          }
+
+          if (baselineJob) {
+            try {
+              await this.persistLetterState(userId, baselineJob, { status: 'error', tone });
+            } catch (persistError) {
+              this.logger.warn(
+                `Failed to persist letter error state for user ${userId}: ${(persistError as Error)?.message ?? persistError}`,
+              );
+            }
+          }
+
+          const message =
+            error instanceof BadRequestException
+              ? error.message
+              : 'Letter composition failed. Please try again in a few moments.';
+
+          send({ type: 'error', message, remainingCredits });
+          complete();
+        } finally {
+          if (controller) {
+            try {
+              controller.abort();
+            } catch {
+              // ignore
+            }
+          }
+        }
+      })();
+
+      return () => {
+        closed = true;
+        if (controller) {
+          try {
+            controller.abort();
+          } catch {
+            // ignore
+          }
+        }
       };
     });
   }
@@ -1089,36 +1579,11 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
       status?: WritingDeskResearchStatus | null | undefined;
     },
   ): UpsertActiveWritingDeskJobDto {
-    const payload: UpsertActiveWritingDeskJobDto = {
-      jobId: job.jobId,
-      phase: job.phase,
-      stepIndex: job.stepIndex,
-      followUpIndex: job.followUpIndex,
-      form: {
-        issueDescription: job.form?.issueDescription ?? '',
-      },
-      followUpQuestions: Array.isArray(job.followUpQuestions) ? [...job.followUpQuestions] : [],
-      followUpAnswers: Array.isArray(job.followUpAnswers) ? [...job.followUpAnswers] : [],
-      notes: job.notes ?? undefined,
-      responseId: job.responseId ?? undefined,
-      researchStatus: job.researchStatus ?? 'idle',
-    };
-
-    const existingContent = this.normaliseResearchContent(job.researchContent ?? null);
-    if (existingContent !== null) {
-      payload.researchContent = existingContent;
-    }
+    const payload = this.buildBaseUpsertPayload(job);
 
     const nextContent = this.normaliseResearchContent(result.content ?? null);
     if (nextContent !== null) {
       payload.researchContent = nextContent;
-    } else if (!payload.researchContent) {
-      payload.researchContent = undefined;
-    }
-
-    const existingResponseId = job.researchResponseId?.toString?.().trim?.();
-    if (existingResponseId) {
-      payload.researchResponseId = existingResponseId;
     }
 
     const researchResponseId = result.responseId?.toString?.().trim?.();
@@ -1133,10 +1598,544 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
     return payload;
   }
 
+  private buildBaseUpsertPayload(job: ActiveWritingDeskJobResource): UpsertActiveWritingDeskJobDto {
+    const payload: UpsertActiveWritingDeskJobDto = {
+      jobId: job.jobId,
+      phase: job.phase,
+      stepIndex: job.stepIndex,
+      followUpIndex: job.followUpIndex,
+      form: {
+        issueDescription: job.form?.issueDescription ?? '',
+      },
+      followUpQuestions: Array.isArray(job.followUpQuestions) ? [...job.followUpQuestions] : [],
+      followUpAnswers: Array.isArray(job.followUpAnswers) ? [...job.followUpAnswers] : [],
+      notes: job.notes ?? undefined,
+      responseId: job.responseId ?? undefined,
+      researchStatus: job.researchStatus ?? 'idle',
+      letterStatus: job.letterStatus ?? 'idle',
+      letterReferences: Array.isArray(job.letterReferences) ? [...job.letterReferences] : [],
+    };
+
+    const existingResearchContent = this.normaliseResearchContent(job.researchContent ?? null);
+    if (existingResearchContent !== null) {
+      payload.researchContent = existingResearchContent;
+    }
+
+    const existingResearchResponseId = job.researchResponseId?.toString?.().trim?.();
+    if (existingResearchResponseId) {
+      payload.researchResponseId = existingResearchResponseId;
+    }
+
+    const existingTone = job.letterTone?.toString?.().trim?.();
+    if (existingTone) {
+      payload.letterTone = existingTone as any;
+    }
+
+    const existingLetterResponseId = job.letterResponseId?.toString?.().trim?.();
+    if (existingLetterResponseId) {
+      payload.letterResponseId = existingLetterResponseId;
+    }
+
+    const existingLetterContent = this.normaliseResearchContent(job.letterContent ?? null);
+    if (existingLetterContent !== null) {
+      payload.letterContent = existingLetterContent;
+    }
+
+    const existingLetterJson = this.normaliseResearchContent(job.letterJson ?? null);
+    if (existingLetterJson !== null) {
+      payload.letterJson = existingLetterJson;
+    }
+
+    return payload;
+  }
+
   private normaliseResearchContent(value: string | null | undefined): string | null {
     if (typeof value !== 'string') return null;
     const normalised = value.replace(/\r\n/g, '\n');
     return normalised.trim().length > 0 ? normalised : null;
+  }
+
+  private normaliseLetterTone(value: string | null | undefined): WritingDeskLetterTone | null {
+    if (typeof value !== 'string') return null;
+    const normalised = value.trim().toLowerCase().replace(/\s+/g, '_');
+    const matched = (WRITING_DESK_LETTER_TONES as readonly string[]).find((tone) => tone === normalised);
+    return (matched as WritingDeskLetterTone | undefined) ?? null;
+  }
+
+  private normaliseLetterVerbosity(raw: string | undefined | null): 'low' | 'medium' | 'high' {
+    const value = raw?.trim?.().toLowerCase?.();
+    if (value === 'low' || value === 'high') return value;
+    return 'medium';
+  }
+
+  private normaliseLetterReasoningEffort(
+    model: string,
+    raw: string | undefined | null,
+  ): 'low' | 'medium' | 'high' {
+    const supported = this.getSupportedReasoningEfforts(model);
+    const requested = raw?.trim?.().toLowerCase?.();
+    if (requested && (supported as readonly string[]).includes(requested)) {
+      return requested as 'low' | 'medium' | 'high';
+    }
+    if (supported.includes('medium')) return 'medium';
+    return supported[0];
+  }
+
+  private async resolveLetterContext(userId: string): Promise<LetterContext> {
+    const [userRecord, addressRecord, mpRecord] = await Promise.all([
+      this.users.findById(userId).catch(() => null),
+      this.userAddress
+        .getMine(userId)
+        .catch(() => ({ address: null })),
+      this.userMp.getMine(userId).catch(() => null),
+    ]);
+
+    const senderNameRaw = (userRecord as any)?.name;
+    const senderName = typeof senderNameRaw === 'string' && senderNameRaw.trim().length > 0 ? senderNameRaw.trim() : '';
+
+    const senderAddress = (addressRecord as any)?.address ?? {};
+    const senderAddress1 = typeof senderAddress?.line1 === 'string' ? senderAddress.line1 : '';
+    const senderAddress2 = typeof senderAddress?.line2 === 'string' ? senderAddress.line2 : '';
+    const senderCity = typeof senderAddress?.city === 'string' ? senderAddress.city : '';
+    const senderCounty = typeof senderAddress?.county === 'string' ? senderAddress.county : '';
+    const senderPostcode = typeof senderAddress?.postcode === 'string' ? senderAddress.postcode : '';
+
+    const mpName =
+      typeof (mpRecord as any)?.mp?.name === 'string' && (mpRecord as any).mp.name.trim().length > 0
+        ? (mpRecord as any).mp.name.trim()
+        : '';
+    const constituency =
+      typeof (mpRecord as any)?.constituency === 'string' && (mpRecord as any).constituency.trim().length > 0
+        ? (mpRecord as any).constituency.trim()
+        : '';
+
+    const parsedMpAddress = this.parseParliamentaryAddress((mpRecord as any)?.mp?.parliamentaryAddress);
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    return {
+      mpName,
+      mpAddress1: parsedMpAddress.line1,
+      mpAddress2: parsedMpAddress.line2,
+      mpCity: parsedMpAddress.city,
+      mpCounty: parsedMpAddress.county,
+      mpPostcode: parsedMpAddress.postcode,
+      constituency,
+      senderName,
+      senderAddress1,
+      senderAddress2,
+      senderAddress3: '',
+      senderCity,
+      senderCounty,
+      senderPostcode,
+      today,
+    };
+  }
+
+  private buildLetterPrompt(params: {
+    job: ActiveWritingDeskJobResource;
+    tone: WritingDeskLetterTone;
+    context: LetterContext;
+    research: string;
+  }): string {
+    const { job, tone, context, research } = params;
+    const toneDetail = LETTER_TONE_DETAILS[tone];
+    const intake = job.form?.issueDescription ?? '';
+    const followUps = Array.isArray(job.followUpQuestions)
+      ? job.followUpQuestions
+          .map((question, index) => {
+            const answer = job.followUpAnswers?.[index] ?? '';
+            if (!question && !answer) return null;
+            return `Question: ${question}\nAnswer: ${answer}`;
+          })
+          .filter((entry): entry is string => !!entry)
+      : [];
+
+    const followUpSection =
+      followUps.length > 0 ? followUps.join('\n\n') : 'No follow-up questions were required.';
+
+    const researchSection = research || 'No deep research findings were available.';
+
+    const sections = [
+      `Selected tone: ${toneDetail.label}. ${toneDetail.prompt}`,
+      `Today's date: ${context.today}`,
+      `MP profile:\n- Name: ${context.mpName || 'Unknown'}\n- Constituency: ${context.constituency || 'Unknown'}\n- Parliamentary address line 1: ${context.mpAddress1 || ''}\n- Parliamentary address line 2: ${context.mpAddress2 || ''}\n- Parliamentary city: ${context.mpCity || ''}\n- Parliamentary county: ${context.mpCounty || ''}\n- Parliamentary postcode: ${context.mpPostcode || ''}`,
+      `Sender profile:\n- Name: ${context.senderName || ''}\n- Address line 1: ${context.senderAddress1 || ''}\n- Address line 2: ${context.senderAddress2 || ''}\n- Address line 3: ${context.senderAddress3 || ''}\n- City: ${context.senderCity || ''}\n- County: ${context.senderCounty || ''}\n- Postcode: ${context.senderPostcode || ''}`,
+      `User intake description:\n${intake}`,
+      `Follow-up details:\n${followUpSection}`,
+      `Deep research findings:\n${researchSection}`,
+    ];
+
+    return sections.join('\n\n');
+  }
+
+  private buildLetterSystemPrompt(): string {
+    return LETTER_SYSTEM_PROMPT;
+  }
+
+  private buildStubLetter(params: {
+    job: ActiveWritingDeskJobResource;
+    tone: WritingDeskLetterTone;
+    context: LetterContext;
+    research: string;
+  }): WritingDeskLetterResult {
+    const { job, tone, context, research } = params;
+    const intake = (job.form?.issueDescription ?? '').trim();
+    const intakeSummary =
+      intake.length > 0
+        ? intake
+        : 'I am raising an urgent local issue that requires your attention on behalf of my household.';
+
+    const qaPairs = Array.isArray(job.followUpQuestions)
+      ? job.followUpQuestions
+          .map((question, index) => {
+            const answer = job.followUpAnswers?.[index] ?? '';
+            if (!(question && question.trim()) && !(answer && answer.trim())) {
+              return null;
+            }
+            return {
+              question: (question ?? '').trim(),
+              answer: (answer ?? '').trim(),
+            };
+          })
+          .filter((value): value is { question: string; answer: string } => !!value)
+          .slice(0, 3)
+      : [];
+
+    const normalisedResearch = research
+      .replace(/\r\n/g, '\n')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    const bulletCandidates = normalisedResearch
+      .filter((line) => /^[-*•]/.test(line))
+      .map((line) => line.replace(/^[-*•]\s*/, ''));
+
+    const processedResearchLines = (bulletCandidates.length > 0 ? bulletCandidates : normalisedResearch)
+      .map((line) => line.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 ($2)'))
+      .map((line) => line.replace(/[*#>`]/g, ''))
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .slice(0, bulletCandidates.length > 0 ? 3 : 2);
+
+    const escapeHtml = (value: string): string =>
+      value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+    const toParagraph = (value: string): string =>
+      `<p>${escapeHtml(value).replace(/\n+/g, '<br />')}</p>`;
+
+    const followUpHtml =
+      qaPairs.length > 0
+        ? `<p><strong>Additional detail previously provided:</strong></p><ul>${qaPairs
+            .map(({ question, answer }) => {
+              const escapedQuestion = escapeHtml(question);
+              if (answer.length === 0) {
+                return `<li><strong>${escapedQuestion}</strong></li>`;
+              }
+              const answerHtml = escapeHtml(` ${answer}`).replace(/\n+/g, '<br />');
+              return `<li><strong>${escapedQuestion}</strong>${answerHtml}</li>`;
+            })
+            .join('')}</ul>`
+        : '';
+
+    let researchHtml = '';
+    if (processedResearchLines.length > 0) {
+      if (processedResearchLines.length === 1) {
+        researchHtml = toParagraph(`Supporting evidence: ${processedResearchLines[0]}`);
+      } else {
+        researchHtml = `<p><strong>Supporting evidence:</strong></p><ul>${processedResearchLines
+          .map((line) => `<li>${escapeHtml(line)}</li>`)
+          .join('')}</ul>`;
+      }
+    }
+
+    const requestPrefix = LETTER_TONE_REQUEST_PREFIX[tone] ?? LETTER_TONE_REQUEST_PREFIX.neutral;
+    const request = `${requestPrefix} raise this issue with the relevant authorities, outline the steps you can take, and keep me informed of any progress.`;
+    const signOff = LETTER_TONE_SIGN_OFFS[tone] ?? LETTER_TONE_SIGN_OFFS.neutral;
+    const senderName = context.senderName || 'A concerned constituent';
+
+    const letterSections: string[] = [
+      toParagraph(
+        `I am writing as a constituent in ${context.constituency || 'our constituency'} to share the following situation: ${intakeSummary}`,
+      ),
+    ];
+
+    if (followUpHtml) {
+      letterSections.push(followUpHtml);
+    }
+
+    if (researchHtml) {
+      letterSections.push(researchHtml);
+    }
+
+    letterSections.push(toParagraph(request));
+    letterSections.push(`<p>${escapeHtml(signOff)}<br />${escapeHtml(senderName)}</p>`);
+
+    return {
+      mp_name: context.mpName || 'Your MP',
+      mp_address_1: context.mpAddress1 || '',
+      mp_address_2: context.mpAddress2 || '',
+      mp_city: context.mpCity || '',
+      mp_county: context.mpCounty || '',
+      mp_postcode: context.mpPostcode || '',
+      date: context.today,
+      letter_content: letterSections.join(''),
+      sender_name: context.senderName || '',
+      sender_address_1: context.senderAddress1 || '',
+      sender_address_2: context.senderAddress2 || '',
+      sender_address_3: context.senderAddress3 || '',
+      sender_city: context.senderCity || '',
+      sender_county: context.senderCounty || '',
+      sender_postcode: context.senderPostcode || '',
+      references: [],
+    };
+  }
+
+  private toLetterCompletePayload(
+    result: WritingDeskLetterResult,
+    extras: { responseId: string | null; tone: WritingDeskLetterTone; rawJson: string },
+  ): LetterCompletePayload {
+    return {
+      mpName: result.mp_name ?? '',
+      mpAddress1: result.mp_address_1 ?? '',
+      mpAddress2: result.mp_address_2 ?? '',
+      mpCity: result.mp_city ?? '',
+      mpCounty: result.mp_county ?? '',
+      mpPostcode: result.mp_postcode ?? '',
+      date: result.date ?? '',
+      letterContent: result.letter_content ?? '',
+      senderName: result.sender_name ?? '',
+      senderAddress1: result.sender_address_1 ?? '',
+      senderAddress2: result.sender_address_2 ?? '',
+      senderAddress3: result.sender_address_3 ?? '',
+      senderCity: result.sender_city ?? '',
+      senderCounty: result.sender_county ?? '',
+      senderPostcode: result.sender_postcode ?? '',
+      references: Array.isArray(result.references) ? result.references : [],
+      responseId: extras.responseId ?? null,
+      tone: extras.tone,
+      rawJson: extras.rawJson,
+    };
+  }
+
+  private parseLetterResult(text: string): WritingDeskLetterResult {
+    try {
+      const parsed = JSON.parse(text) as WritingDeskLetterResult;
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Letter response was not an object');
+      }
+      return {
+        mp_name: parsed.mp_name ?? '',
+        mp_address_1: parsed.mp_address_1 ?? '',
+        mp_address_2: parsed.mp_address_2 ?? '',
+        mp_city: parsed.mp_city ?? '',
+        mp_county: parsed.mp_county ?? '',
+        mp_postcode: parsed.mp_postcode ?? '',
+        date: parsed.date ?? '',
+        letter_content: parsed.letter_content ?? '',
+        sender_name: parsed.sender_name ?? '',
+        sender_address_1: parsed.sender_address_1 ?? '',
+        sender_address_2: parsed.sender_address_2 ?? '',
+        sender_address_3: parsed.sender_address_3 ?? '',
+        sender_city: parsed.sender_city ?? '',
+        sender_county: parsed.sender_county ?? '',
+        sender_postcode: parsed.sender_postcode ?? '',
+        references: Array.isArray(parsed.references) ? parsed.references : [],
+      };
+    } catch (error) {
+      throw new Error(`Failed to parse letter JSON: ${(error as Error)?.message ?? error}`);
+    }
+  }
+
+  private extractOutputTextDelta(event: Record<string, unknown>): string | null {
+    const delta = (event as any)?.delta ?? (event as any)?.text ?? null;
+    return typeof delta === 'string' ? delta : null;
+  }
+
+  private extractLetterPreview(buffer: string): string | null {
+    const marker = '"letter_content":"';
+    const index = buffer.lastIndexOf(marker);
+    if (index === -1) return null;
+    const start = index + marker.length;
+    let result = '';
+    let i = start;
+    while (i < buffer.length) {
+      const char = buffer[i];
+      if (char === '"') {
+        const escaped = i > start && buffer[i - 1] === '\\';
+        if (!escaped) {
+          break;
+        }
+      }
+
+      if (char === '\\') {
+        const next = buffer[i + 1];
+        if (next === 'n') {
+          result += '\n';
+          i += 2;
+          continue;
+        }
+        if (next === 'r') {
+          result += '\n';
+          i += 2;
+          continue;
+        }
+        if (next === 't') {
+          result += '\t';
+          i += 2;
+          continue;
+        }
+        if (next === 'b' || next === 'f') {
+          i += 2;
+          continue;
+        }
+        if (next === '\\' || next === '"') {
+          result += next;
+          i += 2;
+          continue;
+        }
+        if (next === '/') {
+          result += '/';
+          i += 2;
+          continue;
+        }
+        if (next === 'u' && i + 5 < buffer.length) {
+          const code = buffer.slice(i + 2, i + 6);
+          if (/^[0-9a-fA-F]{4}$/.test(code)) {
+            result += String.fromCharCode(parseInt(code, 16));
+            i += 6;
+            continue;
+          }
+        }
+        i += 2;
+        continue;
+      }
+
+      result += char;
+      i += 1;
+    }
+
+    return result;
+  }
+
+  private async persistLetterState(
+    userId: string,
+    fallback: ActiveWritingDeskJobResource,
+    update: {
+      status?: WritingDeskLetterStatus;
+      tone?: WritingDeskLetterTone | null;
+      responseId?: string | null;
+      content?: string | null;
+      references?: string[] | null;
+      json?: string | null;
+    },
+  ) {
+    const latest = await this.writingDeskJobs.getActiveJobForUser(userId);
+    const job = latest ?? fallback;
+    const payload = this.buildLetterUpsertPayload(job, update);
+    await this.writingDeskJobs.upsertActiveJob(userId, payload);
+  }
+
+  private async persistLetterResult(
+    userId: string,
+    fallback: ActiveWritingDeskJobResource,
+    update: {
+      status: WritingDeskLetterStatus;
+      tone?: WritingDeskLetterTone | null;
+      responseId?: string | null;
+      content?: string | null;
+      references?: string[] | null;
+      json?: string | null;
+    },
+  ) {
+    await this.persistLetterState(userId, fallback, update);
+  }
+
+  private buildLetterUpsertPayload(
+    job: ActiveWritingDeskJobResource,
+    update: {
+      status?: WritingDeskLetterStatus;
+      tone?: WritingDeskLetterTone | null;
+      responseId?: string | null;
+      content?: string | null;
+      references?: string[] | null;
+      json?: string | null;
+    },
+  ): UpsertActiveWritingDeskJobDto {
+    const payload = this.buildBaseUpsertPayload(job);
+
+    if (update.status) {
+      payload.letterStatus = update.status;
+    }
+
+    if (update.tone !== undefined) {
+      payload.letterTone = update.tone ?? undefined;
+    }
+
+    if (update.responseId !== undefined) {
+      payload.letterResponseId = update.responseId ?? undefined;
+    }
+
+    if (update.content !== undefined) {
+      const normalised = this.normaliseResearchContent(update.content);
+      payload.letterContent = normalised ?? undefined;
+    }
+
+    if (update.references !== undefined) {
+      payload.letterReferences = Array.isArray(update.references)
+        ? update.references
+            .map((value) => (typeof value === 'string' ? value.trim() : ''))
+            .filter((value) => value.length > 0)
+        : [];
+    }
+
+    if (update.json !== undefined) {
+      const normalisedJson = this.normaliseResearchContent(update.json);
+      payload.letterJson = normalisedJson ?? undefined;
+    }
+
+    return payload;
+  }
+
+  private parseParliamentaryAddress(value: string | null | undefined) {
+    if (typeof value !== 'string') {
+      return { line1: '', line2: '', city: '', county: '', postcode: '' };
+    }
+
+    const segments = value
+      .split(/[\n,]+/)
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0);
+
+    const postcodeRegex = /[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}$/i;
+    let postcode = '';
+    for (let i = segments.length - 1; i >= 0; i -= 1) {
+      const candidate = segments[i];
+      if (postcodeRegex.test(candidate)) {
+        postcode = this.normaliseUkPostcode(candidate);
+        segments.splice(i, 1);
+        break;
+      }
+    }
+
+    const line1 = segments.shift() ?? '';
+    const line2 = segments.shift() ?? '';
+    const city = segments.shift() ?? '';
+    const county = segments.shift() ?? '';
+
+    return { line1, line2, city, county, postcode };
+  }
+
+  private normaliseUkPostcode(input: string): string {
+    const tight = (input || '').replace(/\s+/g, '').toUpperCase();
+    if (!/^[A-Z]{1,2}\d[A-Z\d]?\d[A-Z]{2}$/.test(tight)) return input?.trim?.() ?? '';
+    return `${tight.slice(0, -3)} ${tight.slice(-3)}`;
   }
 
   private normaliseStreamEvent(event: ResponseStreamEvent): Record<string, unknown> {

--- a/backend-api/src/user-address-store/user-address.module.ts
+++ b/backend-api/src/user-address-store/user-address.module.ts
@@ -13,6 +13,7 @@ import { EncryptionService } from '../crypto/encryption.service';
   ],
   controllers: [UserAddressController],
   providers: [UserAddressService, EncryptionService],
+  exports: [UserAddressService],
 })
 export class UserAddressModule {}
 

--- a/backend-api/src/writing-desk-jobs/dto/start-letter.dto.ts
+++ b/backend-api/src/writing-desk-jobs/dto/start-letter.dto.ts
@@ -1,0 +1,11 @@
+import { IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { WRITING_DESK_LETTER_TONES, WritingDeskLetterTone } from '../writing-desk-jobs.types';
+
+export class StartLetterDto {
+  @IsOptional()
+  @IsUUID()
+  jobId?: string;
+
+  @IsEnum(WRITING_DESK_LETTER_TONES)
+  tone!: WritingDeskLetterTone;
+}

--- a/backend-api/src/writing-desk-jobs/dto/upsert-active-writing-desk-job.dto.ts
+++ b/backend-api/src/writing-desk-jobs/dto/upsert-active-writing-desk-job.dto.ts
@@ -12,8 +12,12 @@ import {
 } from 'class-validator';
 import {
   WRITING_DESK_JOB_PHASES,
+  WRITING_DESK_LETTER_STATUSES,
+  WRITING_DESK_LETTER_TONES,
   WRITING_DESK_RESEARCH_STATUSES,
   WritingDeskJobPhase,
+  WritingDeskLetterStatus,
+  WritingDeskLetterTone,
   WritingDeskResearchStatus,
 } from '../writing-desk-jobs.types';
 
@@ -74,4 +78,30 @@ export class UpsertActiveWritingDeskJobDto {
   @IsOptional()
   @IsEnum(WRITING_DESK_RESEARCH_STATUSES)
   researchStatus?: WritingDeskResearchStatus;
+
+  @IsOptional()
+  @IsEnum(WRITING_DESK_LETTER_STATUSES)
+  letterStatus?: WritingDeskLetterStatus;
+
+  @IsOptional()
+  @IsEnum(WRITING_DESK_LETTER_TONES)
+  letterTone?: WritingDeskLetterTone;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  letterResponseId?: string;
+
+  @IsOptional()
+  @IsString()
+  letterContent?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  letterReferences?: string[];
+
+  @IsOptional()
+  @IsString()
+  letterJson?: string;
 }

--- a/backend-api/src/writing-desk-jobs/schema/writing-desk-job.schema.ts
+++ b/backend-api/src/writing-desk-jobs/schema/writing-desk-job.schema.ts
@@ -42,6 +42,24 @@ export class WritingDeskJob {
 
   @Prop({ type: String, default: 'idle' })
   researchStatus!: string;
+
+  @Prop({ type: String, default: 'idle' })
+  letterStatus!: string;
+
+  @Prop({ type: String, default: null })
+  letterTone!: string | null;
+
+  @Prop({ type: String, default: null })
+  letterResponseId!: string | null;
+
+  @Prop({ type: String, default: null })
+  letterContent!: string | null;
+
+  @Prop({ type: [String], default: [] })
+  letterReferences!: string[];
+
+  @Prop({ type: String, default: null })
+  letterJson!: string | null;
 }
 
 export type WritingDeskJobDocument = WritingDeskJob & Document;

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.controller.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.controller.ts
@@ -16,6 +16,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { WritingDeskJobsService } from './writing-desk-jobs.service';
 import { UpsertActiveWritingDeskJobDto } from './dto/upsert-active-writing-desk-job.dto';
 import { StartDeepResearchDto } from './dto/start-deep-research.dto';
+import { StartLetterDto } from './dto/start-letter.dto';
 import { AiService } from '../ai/ai.service';
 
 @UseGuards(JwtAuthGuard)
@@ -66,6 +67,27 @@ export class WritingDeskJobsController {
     return {
       jobId: activeJob.jobId,
       streamPath: `/api/ai/writing-desk/deep-research?${params.toString()}`,
+    };
+  }
+
+  @Post('letter/start')
+  async startLetter(@Req() req: any, @Body() body: StartLetterDto) {
+    const activeJob = await this.jobs.getActiveJobForUser(req.user.id);
+    if (!activeJob) {
+      throw new BadRequestException('We could not find an active letter to compose. Save your answers and try again.');
+    }
+
+    if (body?.jobId && body.jobId !== activeJob.jobId) {
+      throw new ConflictException('Your saved letter changed. Refresh the page before composing the letter again.');
+    }
+
+    const params = new URLSearchParams();
+    params.set('jobId', activeJob.jobId);
+    params.set('tone', body.tone);
+
+    return {
+      jobId: activeJob.jobId,
+      streamPath: `/api/ai/writing-desk/letter?${params.toString()}`,
     };
   }
 }

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.repository.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.repository.ts
@@ -31,6 +31,12 @@ export class WritingDeskJobsRepository {
       researchContent: string | null;
       researchResponseId: string | null;
       researchStatus: string;
+      letterStatus: string;
+      letterTone: string | null;
+      letterResponseId: string | null;
+      letterContent: string | null;
+      letterReferences: string[];
+      letterJson: string | null;
     },
   ): Promise<WritingDeskJobRecord> {
     const doc = await this.model

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.service.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.service.ts
@@ -7,7 +7,11 @@ import {
   WritingDeskJobSnapshot,
   WritingDeskJobFormSnapshot,
   WritingDeskJobRecord,
+  WRITING_DESK_LETTER_STATUSES,
+  WRITING_DESK_LETTER_TONES,
   WRITING_DESK_RESEARCH_STATUSES,
+  WritingDeskLetterStatus,
+  WritingDeskLetterTone,
   WritingDeskResearchStatus,
 } from './writing-desk-jobs.types';
 import { EncryptionService } from '../crypto/encryption.service';
@@ -46,6 +50,12 @@ export class WritingDeskJobsService {
       researchContent: sanitized.researchContent,
       researchResponseId: sanitized.researchResponseId,
       researchStatus: sanitized.researchStatus,
+      letterStatus: sanitized.letterStatus,
+      letterTone: sanitized.letterTone,
+      letterResponseId: sanitized.letterResponseId,
+      letterContent: sanitized.letterContent,
+      letterReferences: sanitized.letterReferences,
+      letterJson: sanitized.letterJson,
     };
 
     const saved = await this.repository.upsertActiveJob(userId, payload);
@@ -108,6 +118,22 @@ export class WritingDeskJobsService {
       ? (rawStatus as WritingDeskResearchStatus)
       : 'idle';
 
+    const rawLetterStatus = typeof input.letterStatus === 'string' ? input.letterStatus.trim() : '';
+    const letterStatus = (WRITING_DESK_LETTER_STATUSES as readonly string[]).includes(rawLetterStatus)
+      ? (rawLetterStatus as WritingDeskLetterStatus)
+      : 'idle';
+
+    const rawLetterTone = typeof input.letterTone === 'string' ? input.letterTone.trim() : '';
+    const letterTone = (WRITING_DESK_LETTER_TONES as readonly string[]).includes(rawLetterTone)
+      ? (rawLetterTone as WritingDeskLetterTone)
+      : null;
+
+    const letterReferences = Array.isArray(input.letterReferences)
+      ? input.letterReferences
+          .map((value) => trim(value))
+          .filter((value) => value.length > 0)
+      : [];
+
     return {
       phase: input.phase,
       stepIndex,
@@ -120,6 +146,12 @@ export class WritingDeskJobsService {
       researchContent: normaliseMultiline(input.researchContent),
       researchResponseId: trimNullable(input.researchResponseId),
       researchStatus,
+      letterStatus,
+      letterTone,
+      letterResponseId: trimNullable(input.letterResponseId),
+      letterContent: normaliseMultiline(input.letterContent),
+      letterReferences,
+      letterJson: normaliseMultiline(input.letterJson),
     };
   }
 
@@ -144,6 +176,14 @@ export class WritingDeskJobsService {
       researchContent: record.researchContent ?? null,
       researchResponseId: record.researchResponseId ?? null,
       researchStatus: (record as any)?.researchStatus ?? 'idle',
+      letterStatus: (record as any)?.letterStatus ?? 'idle',
+      letterTone: (record as any)?.letterTone ?? null,
+      letterResponseId: (record as any)?.letterResponseId ?? null,
+      letterContent: record.letterContent ?? null,
+      letterReferences: Array.isArray((record as any)?.letterReferences)
+        ? ((record as any).letterReferences as string[])
+        : [],
+      letterJson: (record as any)?.letterJson ?? null,
       createdAt,
       updatedAt,
     };
@@ -218,6 +258,12 @@ export class WritingDeskJobsService {
       researchContent: snapshot.researchContent ?? null,
       researchResponseId: snapshot.researchResponseId ?? null,
       researchStatus: snapshot.researchStatus,
+      letterStatus: snapshot.letterStatus,
+      letterTone: snapshot.letterTone ?? null,
+      letterResponseId: snapshot.letterResponseId ?? null,
+      letterContent: snapshot.letterContent ?? null,
+      letterReferences: Array.isArray(snapshot.letterReferences) ? snapshot.letterReferences : [],
+      letterJson: snapshot.letterJson ?? null,
       createdAt: snapshot.createdAt?.toISOString?.() ?? new Date().toISOString(),
       updatedAt: snapshot.updatedAt?.toISOString?.() ?? new Date().toISOString(),
     };

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
@@ -6,6 +6,20 @@ export const WRITING_DESK_RESEARCH_STATUSES = ['idle', 'running', 'completed', '
 
 export type WritingDeskResearchStatus = (typeof WRITING_DESK_RESEARCH_STATUSES)[number];
 
+export const WRITING_DESK_LETTER_STATUSES = ['idle', 'generating', 'completed', 'error'] as const;
+
+export type WritingDeskLetterStatus = (typeof WRITING_DESK_LETTER_STATUSES)[number];
+
+export const WRITING_DESK_LETTER_TONES = [
+  'formal',
+  'polite_but_firm',
+  'empathetic',
+  'urgent',
+  'neutral',
+] as const;
+
+export type WritingDeskLetterTone = (typeof WRITING_DESK_LETTER_TONES)[number];
+
 export interface WritingDeskJobFormSnapshot {
   issueDescription: string;
 }
@@ -24,6 +38,12 @@ export interface WritingDeskJobSnapshot {
   researchContent: string | null;
   researchResponseId: string | null;
   researchStatus: WritingDeskResearchStatus;
+  letterStatus: WritingDeskLetterStatus;
+  letterTone: WritingDeskLetterTone | null;
+  letterResponseId: string | null;
+  letterContent: string | null;
+  letterReferences: string[];
+  letterJson: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -49,6 +69,12 @@ export interface WritingDeskJobRecord {
   researchContent: string | null;
   researchResponseId: string | null;
   researchStatus: WritingDeskResearchStatus;
+  letterStatus: WritingDeskLetterStatus;
+  letterTone: WritingDeskLetterTone | null;
+  letterResponseId: string | null;
+  letterContent: string | null;
+  letterReferences: string[];
+  letterJson: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -66,6 +92,12 @@ export interface ActiveWritingDeskJobResource {
   researchContent: string | null;
   researchResponseId: string | null;
   researchStatus: WritingDeskResearchStatus;
+  letterStatus: WritingDeskLetterStatus;
+  letterTone: WritingDeskLetterTone | null;
+  letterResponseId: string | null;
+  letterContent: string | null;
+  letterReferences: string[];
+  letterJson: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -2017,3 +2017,4 @@ export default function WritingDeskClient() {
     </>
   );
 }
+

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -6,7 +6,14 @@ import ActiveJobResumeModal from '../../features/writing-desk/components/ActiveJ
 import EditIntakeConfirmModal from '../../features/writing-desk/components/EditIntakeConfirmModal';
 import StartOverConfirmModal from '../../features/writing-desk/components/StartOverConfirmModal';
 import { useActiveWritingDeskJob } from '../../features/writing-desk/hooks/useActiveWritingDeskJob';
-import { ActiveWritingDeskJob, UpsertActiveWritingDeskJobPayload } from '../../features/writing-desk/types';
+import {
+  ActiveWritingDeskJob,
+  UpsertActiveWritingDeskJobPayload,
+  WritingDeskLetterStatus,
+  WritingDeskLetterTone,
+  WRITING_DESK_LETTER_TONES,
+} from '../../features/writing-desk/types';
+import { startLetterComposition } from '../../features/writing-desk/api/letter';
 
 type StepKey = 'issueDescription';
 
@@ -32,6 +39,29 @@ const initialFormState: FormState = {
   issueDescription: '',
 };
 
+const LETTER_TONE_LABELS: Record<WritingDeskLetterTone, { label: string; description: string }> = {
+  formal: {
+    label: 'Formal',
+    description: 'Traditional parliamentary tone: respectful, precise, and structured.',
+  },
+  polite_but_firm: {
+    label: 'Polite but firm',
+    description: 'Courteous but clear about expectations and urgency.',
+  },
+  empathetic: {
+    label: 'Empathetic',
+    description: 'Centres the human impact with warmth and compassion.',
+  },
+  urgent: {
+    label: 'Urgent',
+    description: 'Direct and time-sensitive while remaining respectful.',
+  },
+  neutral: {
+    label: 'Neutral',
+    description: 'Calm, factual tone that lets the evidence speak for itself.',
+  },
+};
+
 type ResearchStatus = 'idle' | 'running' | 'completed' | 'error';
 
 type DeepResearchStreamMessage =
@@ -53,6 +83,36 @@ type DeepResearchHandshakeResponse = {
 };
 
 const MAX_RESEARCH_ACTIVITY_ITEMS = 10;
+
+interface LetterStreamLetterPayload {
+  mpName: string;
+  mpAddress1: string;
+  mpAddress2: string;
+  mpCity: string;
+  mpCounty: string;
+  mpPostcode: string;
+  date: string;
+  letterContent: string;
+  senderName: string;
+  senderAddress1: string;
+  senderAddress2: string;
+  senderAddress3: string;
+  senderCity: string;
+  senderCounty: string;
+  senderPostcode: string;
+  references: string[];
+  responseId: string | null;
+  tone: WritingDeskLetterTone;
+  rawJson: string;
+}
+
+type LetterStreamMessage =
+  | { type: 'status'; status: string; remainingCredits?: number | null }
+  | { type: 'event'; event: { type?: string; [key: string]: any } }
+  | { type: 'delta'; text: string }
+  | { type: 'letter_delta'; html: string }
+  | { type: 'complete'; letter: LetterStreamLetterPayload; remainingCredits: number | null }
+  | { type: 'error'; message: string; remainingCredits?: number | null };
 
 const extractReasoningSummary = (value: unknown): string | null => {
   if (typeof value === 'string') {
@@ -186,6 +246,22 @@ export default function WritingDeskClient() {
   const previousPhaseRef = useRef<'initial' | 'generating' | 'followup' | 'summary'>();
   const lastResearchEventRef = useRef<number>(0);
   const lastResearchResumeAttemptRef = useRef<number>(0);
+  const [letterStatus, setLetterStatus] = useState<WritingDeskLetterStatus>('idle');
+  const [letterPhase, setLetterPhase] = useState<'idle' | 'tone' | 'streaming' | 'completed' | 'error'>('idle');
+  const [selectedTone, setSelectedTone] = useState<WritingDeskLetterTone | null>(null);
+  const [letterContentHtml, setLetterContentHtml] = useState<string>('');
+  const [letterReferences, setLetterReferences] = useState<string[]>([]);
+  const [letterResponseId, setLetterResponseId] = useState<string | null>(null);
+  const [letterRawJson, setLetterRawJson] = useState<string | null>(null);
+  const [letterError, setLetterError] = useState<string | null>(null);
+  const [letterEvents, setLetterEvents] = useState<Array<{ id: string; text: string }>>([]);
+  const [letterStatusMessage, setLetterStatusMessage] = useState<string | null>(null);
+  const [letterCopyState, setLetterCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+  const [letterRemainingCredits, setLetterRemainingCredits] = useState<number | null>(null);
+  const [letterReasoningVisible, setLetterReasoningVisible] = useState(true);
+  const [letterMetadata, setLetterMetadata] = useState<LetterStreamLetterPayload | null>(null);
+  const letterSourceRef = useRef<EventSource | null>(null);
+  const letterJsonBufferRef = useRef<string>('');
 
   const currentStep = phase === 'initial' ? steps[stepIndex] ?? null : null;
   const followUpCreditCost = 0.1;
@@ -216,6 +292,32 @@ export default function WritingDeskClient() {
     }
   }, []);
 
+  const closeLetterStream = useCallback(() => {
+    if (letterSourceRef.current) {
+      letterSourceRef.current.close();
+      letterSourceRef.current = null;
+    }
+  }, []);
+
+  const resetLetter = useCallback(() => {
+    closeLetterStream();
+    setLetterStatus('idle');
+    setLetterPhase('idle');
+    setSelectedTone(null);
+    setLetterContentHtml('');
+    setLetterReferences([]);
+    setLetterResponseId(null);
+    setLetterRawJson(null);
+    setLetterError(null);
+    setLetterEvents([]);
+    setLetterStatusMessage(null);
+    setLetterCopyState('idle');
+    setLetterRemainingCredits(null);
+    setLetterReasoningVisible(true);
+    setLetterMetadata(null);
+    letterJsonBufferRef.current = '';
+  }, [closeLetterStream]);
+
   const resetResearch = useCallback(() => {
     closeResearchStream();
     setResearchContent('');
@@ -228,6 +330,14 @@ export default function WritingDeskClient() {
 
   const appendResearchActivity = useCallback((text: string) => {
     setResearchActivities((prev) => {
+      const entry = { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, text };
+      const next = [entry, ...prev];
+      return next.slice(0, MAX_RESEARCH_ACTIVITY_ITEMS);
+    });
+  }, []);
+
+  const appendLetterEvent = useCallback((text: string) => {
+    setLetterEvents((prev) => {
       const entry = { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, text };
       const next = [entry, ...prev];
       return next.slice(0, MAX_RESEARCH_ACTIVITY_ITEMS);
@@ -326,6 +436,16 @@ export default function WritingDeskClient() {
     };
   }, [closeResearchStream]);
 
+  useEffect(() => {
+    return () => {
+      closeLetterStream();
+    };
+  }, [closeLetterStream]);
+
+  useEffect(() => {
+    setLetterCopyState('idle');
+  }, [letterContentHtml]);
+
   const generatingMessage = `Generating follow-up questions${'.'.repeat((ellipsisCount % 5) + 1)}`;
 
   const resetFollowUps = useCallback(() => {
@@ -335,7 +455,8 @@ export default function WritingDeskClient() {
     setNotes(null);
     setResponseId(null);
     resetResearch();
-  }, [resetResearch]);
+    resetLetter();
+  }, [resetLetter, resetResearch]);
 
   const resetLocalState = useCallback(() => {
     setForm({ ...initialFormState });
@@ -347,7 +468,8 @@ export default function WritingDeskClient() {
     setLoading(false);
     setShowSummaryDetails(false);
     resetFollowUps();
-  }, [resetFollowUps]);
+    resetLetter();
+  }, [resetFollowUps, resetLetter]);
 
   const startDeepResearch = useCallback(
     async (options?: { resume?: boolean }) => {
@@ -531,6 +653,145 @@ export default function WritingDeskClient() {
     };
   }, [appendResearchActivity, closeResearchStream, researchStatus, startDeepResearch]);
 
+  const openLetterStream = useCallback(
+    (streamPath: string) => {
+      closeLetterStream();
+      setLetterStatus('generating');
+      setLetterPhase('streaming');
+      setLetterStatusMessage('Composing your letter…');
+      setLetterError(null);
+      setLetterContentHtml('');
+      setLetterReferences([]);
+      setLetterResponseId(null);
+      setLetterRawJson(null);
+      setLetterRemainingCredits(null);
+      setLetterCopyState('idle');
+      setLetterReasoningVisible(true);
+      letterJsonBufferRef.current = '';
+      const source = new EventSource(streamPath, { withCredentials: true });
+      letterSourceRef.current = source;
+
+      source.onmessage = (event) => {
+        let payload: LetterStreamMessage | null = null;
+        try {
+          payload = JSON.parse(event.data) as LetterStreamMessage;
+        } catch {
+          return;
+        }
+        if (!payload) return;
+
+        if (payload.type === 'status') {
+          setLetterStatusMessage(payload.status);
+          updateCreditsFromStream(payload.remainingCredits);
+          if (typeof payload.remainingCredits === 'number') {
+            setLetterRemainingCredits(Math.round(payload.remainingCredits * 100) / 100);
+          }
+          return;
+        }
+
+        if (payload.type === 'event') {
+          const summary = describeResearchEvent(payload.event);
+          if (summary) {
+            appendLetterEvent(summary);
+          }
+          return;
+        }
+
+        if (payload.type === 'delta') {
+          if (typeof payload.text === 'string') {
+            letterJsonBufferRef.current += payload.text;
+            setLetterRawJson(letterJsonBufferRef.current);
+          }
+          return;
+        }
+
+        if (payload.type === 'letter_delta') {
+          if (typeof payload.html === 'string') {
+            setLetterContentHtml(payload.html);
+            setLetterReasoningVisible(false);
+          }
+          return;
+        }
+
+        if (payload.type === 'complete') {
+          updateCreditsFromStream(payload.remainingCredits);
+          if (typeof payload.remainingCredits === 'number') {
+            setLetterRemainingCredits(Math.round(payload.remainingCredits * 100) / 100);
+          }
+          setLetterReasoningVisible(false);
+          setLetterStatus('completed');
+          setLetterPhase('completed');
+          setLetterStatusMessage('Letter ready');
+          setLetterContentHtml(payload.letter.letterContent);
+          setLetterReferences(payload.letter.references ?? []);
+          setLetterResponseId(payload.letter.responseId ?? null);
+          setLetterRawJson(payload.letter.rawJson ?? null);
+          setSelectedTone(payload.letter.tone ?? null);
+          setLetterMetadata(payload.letter);
+          letterJsonBufferRef.current = payload.letter.rawJson ?? '';
+          setLetterError(null);
+          closeLetterStream();
+          return;
+        }
+
+        if (payload.type === 'error') {
+          updateCreditsFromStream(payload.remainingCredits);
+          if (typeof payload.remainingCredits === 'number') {
+            setLetterRemainingCredits(Math.round(payload.remainingCredits * 100) / 100);
+          }
+          setLetterStatus('error');
+          setLetterPhase('error');
+          setLetterError(payload.message);
+          setLetterStatusMessage(null);
+          setLetterMetadata(null);
+          closeLetterStream();
+        }
+      };
+
+      source.onerror = () => {
+        closeLetterStream();
+        setLetterStatus('error');
+      setLetterPhase('error');
+      setLetterError('The letter stream disconnected. Please try again.');
+      setLetterStatusMessage(null);
+    };
+  },
+  [appendLetterEvent, closeLetterStream, updateCreditsFromStream],
+  );
+
+  const beginLetterComposition = useCallback(
+    async (tone: WritingDeskLetterTone) => {
+      setLetterStatus('generating');
+      setLetterPhase('streaming');
+      setLetterStatusMessage('Preparing your letter request…');
+      setLetterError(null);
+      setSelectedTone(tone);
+      setLetterEvents([]);
+      setLetterCopyState('idle');
+      setLetterRemainingCredits(null);
+      setLetterReasoningVisible(true);
+      letterJsonBufferRef.current = '';
+
+      try {
+        const handshake = await startLetterComposition({ jobId: jobId ?? undefined, tone });
+        if (handshake?.jobId) {
+          setJobId(handshake.jobId);
+        }
+        const url = new URL(handshake.streamPath, window.location.origin);
+        if (!url.searchParams.has('jobId') && (jobId ?? handshake?.jobId)) {
+          url.searchParams.set('jobId', (jobId ?? handshake.jobId) as string);
+        }
+        openLetterStream(url.toString());
+      } catch (error: any) {
+        setLetterStatus('error');
+        setLetterPhase('error');
+        setLetterError(error?.message || 'We could not start letter composition. Please try again.');
+        setLetterStatusMessage(null);
+      }
+    },
+    [jobId, openLetterStream, setJobId],
+  );
+
   const applySnapshot = useCallback(
     (job: ActiveWritingDeskJob) => {
       closeResearchStream();
@@ -561,6 +822,72 @@ export default function WritingDeskClient() {
       setShowSummaryDetails(false);
       setLoading(false);
       setJobSaveError(null);
+      const nextLetterStatus = job.letterStatus ?? 'idle';
+      setLetterStatus(nextLetterStatus);
+      setSelectedTone(job.letterTone ?? null);
+      setLetterReferences(Array.isArray(job.letterReferences) ? [...job.letterReferences] : []);
+      setLetterResponseId(job.letterResponseId ?? null);
+      setLetterRawJson(job.letterJson ?? null);
+      letterJsonBufferRef.current = '';
+      if (job.letterJson) {
+        try {
+          const parsed = JSON.parse(job.letterJson) as Record<string, any>;
+          setLetterMetadata({
+            mpName: parsed.mp_name ?? '',
+            mpAddress1: parsed.mp_address_1 ?? '',
+            mpAddress2: parsed.mp_address_2 ?? '',
+            mpCity: parsed.mp_city ?? '',
+            mpCounty: parsed.mp_county ?? '',
+            mpPostcode: parsed.mp_postcode ?? '',
+            date: parsed.date ?? '',
+            letterContent: parsed.letter_content ?? '',
+            senderName: parsed.sender_name ?? '',
+            senderAddress1: parsed.sender_address_1 ?? '',
+            senderAddress2: parsed.sender_address_2 ?? '',
+            senderAddress3: parsed.sender_address_3 ?? '',
+            senderCity: parsed.sender_city ?? '',
+            senderCounty: parsed.sender_county ?? '',
+            senderPostcode: parsed.sender_postcode ?? '',
+            references: Array.isArray(parsed.references) ? parsed.references : [],
+            responseId: job.letterResponseId ?? null,
+            tone: job.letterTone ?? null,
+            rawJson: job.letterJson ?? '',
+          });
+        } catch {
+          setLetterMetadata(null);
+        }
+      } else {
+        setLetterMetadata(null);
+      }
+      if (nextLetterStatus === 'completed' && typeof job.letterContent === 'string') {
+        setLetterContentHtml(job.letterContent);
+        setLetterPhase('completed');
+        setLetterError(null);
+        setLetterStatusMessage(null);
+        setLetterRemainingCredits(null);
+        setLetterReasoningVisible(false);
+      } else if (nextLetterStatus === 'generating') {
+        setLetterContentHtml('');
+        setLetterPhase('error');
+        setLetterError('Letter drafting was interrupted. Start a new letter to continue.');
+        setLetterReasoningVisible(true);
+        setLetterMetadata(null);
+      } else if (nextLetterStatus === 'error') {
+        setLetterContentHtml(job.letterContent ?? '');
+        setLetterPhase('error');
+        setLetterError('Letter drafting did not finish. Start again when ready.');
+        setLetterReasoningVisible(true);
+        setLetterMetadata(null);
+      } else {
+        setLetterContentHtml(job.letterContent ?? '');
+        setLetterPhase('idle');
+        setLetterError(null);
+        setLetterStatusMessage(null);
+        setLetterReasoningVisible(true);
+        if (!job.letterJson) {
+          setLetterMetadata(null);
+        }
+      }
     },
     [closeResearchStream, resetFollowUps],
   );
@@ -581,6 +908,12 @@ export default function WritingDeskClient() {
       researchContent: job.researchContent ?? null,
       researchResponseId: job.researchResponseId ?? null,
       researchStatus: job.researchStatus ?? 'idle',
+      letterStatus: job.letterStatus ?? 'idle',
+      letterTone: job.letterTone ?? null,
+      letterResponseId: job.letterResponseId ?? null,
+      letterContent: job.letterContent ?? null,
+      letterReferences: Array.isArray(job.letterReferences) ? [...job.letterReferences] : [],
+      letterJson: job.letterJson ?? null,
     }),
     [],
   );
@@ -599,6 +932,12 @@ export default function WritingDeskClient() {
       researchContent,
       researchResponseId: researchResponseId ?? null,
       researchStatus,
+      letterStatus,
+      letterTone: selectedTone,
+      letterResponseId: letterResponseId ?? null,
+      letterContent: letterContentHtml || null,
+      letterReferences,
+      letterJson: letterRawJson,
     }),
     [
       followUpAnswers,
@@ -613,6 +952,12 @@ export default function WritingDeskClient() {
       researchStatus,
       responseId,
       stepIndex,
+      letterStatus,
+      selectedTone,
+      letterResponseId,
+      letterContentHtml,
+      letterReferences,
+      letterRawJson,
     ],
   );
 
@@ -990,8 +1335,58 @@ export default function WritingDeskClient() {
   }, [followUps.length]);
 
   const handleRegenerateFollowUps = useCallback(() => {
+    resetLetter();
     void generateFollowUps('summary');
-  }, [generateFollowUps]);
+  }, [generateFollowUps, resetLetter]);
+
+  const handleShowToneSelection = useCallback(() => {
+    if (letterStatus !== 'idle') {
+      resetLetter();
+    }
+    setLetterPhase('tone');
+    setLetterStatusMessage(null);
+    setLetterError(null);
+    setShowSummaryDetails(false);
+  }, [letterStatus, resetLetter]);
+
+  const handleToneSelect = useCallback(
+    (tone: WritingDeskLetterTone) => {
+      void beginLetterComposition(tone);
+    },
+    [beginLetterComposition],
+  );
+
+  const handleCopyLetter = useCallback(async () => {
+    if (!letterContentHtml) {
+      setLetterCopyState('error');
+      return;
+    }
+    try {
+      if (typeof window !== 'undefined' && 'ClipboardItem' in window && navigator.clipboard && 'write' in navigator.clipboard) {
+        const htmlBlob = new Blob([letterContentHtml], { type: 'text/html' });
+        const plainText = letterContentHtml.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+        const textBlob = new Blob([plainText], { type: 'text/plain' });
+        const item = new (window as any).ClipboardItem({ 'text/html': htmlBlob, 'text/plain': textBlob });
+        await (navigator.clipboard as any).write([item]);
+      } else if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(letterContentHtml);
+      } else {
+        throw new Error('Clipboard API not available');
+      }
+      setLetterCopyState('copied');
+    } catch (error) {
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(letterContentHtml);
+          setLetterCopyState('copied');
+          return;
+        }
+      } catch {
+        // ignore nested failure
+      }
+      setLetterCopyState('error');
+    }
+  }, [letterContentHtml]);
 
   return (
     <>
@@ -1222,227 +1617,373 @@ export default function WritingDeskClient() {
 
         {phase === 'summary' && (
           <div className="result" aria-live="polite">
-            <h3 className="section-title" style={{ fontSize: '1.25rem' }}>Initial summary captured</h3>
-            <p className="section-sub">Thanks for all the information. When you’re ready, click the research button and I’ll dig into the evidence.</p>
-
-            {serverError && (
-              <div className="status" aria-live="assertive" style={{ marginTop: 12 }}>
-                <p style={{ color: '#b91c1c' }}>{serverError}</p>
-              </div>
-            )}
-
-            <div className="card" style={{ padding: 16, marginTop: 16 }}>
-              <h4 className="section-title" style={{ fontSize: '1rem' }}>Research evidence</h4>
-              {!hasResearchContent && researchStatus !== 'running' && (
-                <p style={{ marginTop: 8 }}>
-                  Run research to gather cited evidence that supports your letter. We&apos;ll use the research to craft the perfect impactful letter.
-                </p>
-              )}
-              {researchStatus === 'error' && researchError && (
-                <div className="status" aria-live="assertive" style={{ marginTop: 12 }}>
-                  <p style={{ color: '#b91c1c' }}>{researchError}</p>
-                </div>
-              )}
-              <div style={{ marginTop: 12 }}>
-                <button
-                  type="button"
-                  className="btn-primary"
-                  onClick={startDeepResearch}
-                  disabled={researchButtonDisabled}
-                >
-                  {researchButtonLabel}
-                </button>
-                {researchCreditState === 'low' && (
-                  <p style={{ marginTop: 8, color: '#b91c1c' }}>
-                    You need at least {formatCredits(deepResearchCreditCost)} credits to run deep research.
-                  </p>
-                )}
-                {researchCreditState === 'loading' && (
-                  <p style={{ marginTop: 8, color: '#2563eb' }}>Checking your available credits…</p>
-                )}
-              </div>
-              {researchStatus === 'running' && (
-                <div className="research-progress" role="status" aria-live="polite">
-                  <span className="research-progress__spinner" aria-hidden="true" />
-                  <div className="research-progress__content">
-                    <p>
-                      Gathering evidence — this may take several minutes, please be patient and have a cup of tea.
-                    </p>
-                    <p>We&apos;ll keep posting updates in the activity feed below while the research continues.</p>
-                  </div>
-                </div>
-              )}
-              {researchStatus === 'running' && researchActivities.length > 0 && (
-                <div style={{ marginTop: 12 }}>
-                  <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>Latest activity</h5>
-                  <ul style={{ paddingLeft: 18, margin: 0 }}>
-                    {researchActivities.map((activity) => (
-                      <li key={activity.id} style={{ marginBottom: 4 }}>
-                        {activity.text}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {(hasResearchContent || researchStatus === 'running') && (
-                <div style={{ marginTop: 12 }}>
-                  <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>Research notes</h5>
-                  <div className="research-notes">
-                    {researchContent ? (
-                      <ReactMarkdown
-                        skipHtml
-                        components={{
-                          a: ({ node, ...props }) => (
-                            <a {...props} target="_blank" rel="noreferrer noopener" />
-                          ),
-                        }}
-                      >
-                        {researchContent}
-                      </ReactMarkdown>
-                    ) : (
-                      <p className="research-notes__placeholder">Collecting evidence…</p>
-                    )}
-                  </div>
-                </div>
-              )}
-              {researchResponseId && (
-                <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#6b7280' }}>
-                  Research reference ID: {researchResponseId}
-                </p>
-              )}
-            </div>
-
-            <div
-              style={{
-                marginTop: 12,
-                display: 'flex',
-                flexWrap: 'wrap',
-                alignItems: 'center',
-                gap: 12,
-              }}
-            >
-              <button
-                type="button"
-                className="btn-link"
-                onClick={() => setShowSummaryDetails((prev) => !prev)}
-                disabled={loading}
-              >
-                {showSummaryDetails ? 'Hide intake details' : 'Show intake details'}
-              </button>
-              {responseId && !showSummaryDetails && (
-                <span style={{ fontSize: '0.85rem', color: '#6b7280' }}>Reference ID: {responseId}</span>
-              )}
-            </div>
-
-            {showSummaryDetails && (
+            {letterPhase === 'idle' && (
               <>
-                <div className="card" style={{ padding: 16, marginTop: 16 }}>
-                  <h4 className="section-title" style={{ fontSize: '1rem' }}>What you told us</h4>
-                  <div className="stack" style={{ marginTop: 12 }}>
-                    {steps.map((step) => (
-                      <div key={step.key} style={{ marginBottom: 16 }}>
-                        <div>
-                          <h5 style={{ margin: 0, fontWeight: 600, fontSize: '1rem' }}>{step.title}</h5>
-                        </div>
-                        <p style={{ margin: '6px 0 0 0' }}>{form[step.key]}</p>
-                      </div>
-                    ))}
+                <h3 className="section-title" style={{ fontSize: '1.25rem' }}>Initial summary captured</h3>
+                <p className="section-sub">Thanks for all the information. When you’re ready, click the research button and I’ll dig into the evidence.</p>
+
+                {serverError && (
+                  <div className="status" aria-live="assertive" style={{ marginTop: 12 }}>
+                    <p style={{ color: '#b91c1c' }}>{serverError}</p>
                   </div>
-                </div>
+                )}
 
                 <div className="card" style={{ padding: 16, marginTop: 16 }}>
-                  <h4 className="section-title" style={{ fontSize: '1rem' }}>Follow-up questions</h4>
-                  {followUps.length > 0 ? (
-                    <ol style={{ marginTop: 8, paddingLeft: 20 }}>
-                      {followUps.map((q, idx) => (
-                        <li key={idx} style={{ marginBottom: 12 }}>
-                          <div
-                            style={{
-                              display: 'flex',
-                              justifyContent: 'space-between',
-                              alignItems: 'flex-start',
-                              gap: 12,
-                            }}
-                          >
-                            <p style={{ marginBottom: 4 }}>{q}</p>
-                            <button
-                              type="button"
-                              className="btn-link"
-                              onClick={() => handleEditFollowUpQuestion(idx)}
-                              aria-label={`Edit answer for follow-up question ${idx + 1}`}
-                              disabled={loading}
-                            >
-                              Edit answer
-                            </button>
-                          </div>
-                          <p style={{ margin: 0, fontWeight: 600 }}>Your answer:</p>
-                          <p style={{ margin: '4px 0 0 0' }}>{followUpAnswers[idx]}</p>
-                        </li>
-                      ))}
-                    </ol>
-                  ) : (
-                    <p style={{ marginTop: 8 }}>No additional questions needed — we have enough detail for the next step.</p>
+                  <h4 className="section-title" style={{ fontSize: '1rem' }}>Research evidence</h4>
+                  {!hasResearchContent && researchStatus !== 'running' && (
+                    <p style={{ marginTop: 8 }}>
+                      Run research to gather cited evidence that supports your letter. We&apos;ll use the research to craft the perfect impactful letter.
+                    </p>
                   )}
-                  {followUps.length > 0 && (
-                    <div className="actions" style={{ marginTop: 12 }}>
-                      <button
-                        type="button"
-                        className="btn-link"
-                        onClick={handleRegenerateFollowUps}
-                        disabled={loading}
-                      >
-                        Ask for new follow-up questions (costs {formatCredits(followUpCreditCost)} credits)
-                      </button>
+                  {researchStatus === 'error' && researchError && (
+                    <div className="status" aria-live="assertive" style={{ marginTop: 12 }}>
+                      <p style={{ color: '#b91c1c' }}>{researchError}</p>
                     </div>
                   )}
-                  {notes && <p style={{ marginTop: 8, fontStyle: 'italic' }}>{notes}</p>}
-                  {responseId && (
-                    <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#6b7280' }}>Reference ID: {responseId}</p>
+                  <div style={{ marginTop: 12 }}>
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      onClick={startDeepResearch}
+                      disabled={researchButtonDisabled}
+                    >
+                      {researchButtonLabel}
+                    </button>
+                    {researchCreditState === 'low' && (
+                      <p style={{ marginTop: 8, color: '#b91c1c' }}>
+                        You need at least {formatCredits(deepResearchCreditCost)} credits to run deep research.
+                      </p>
+                    )}
+                    {researchCreditState === 'loading' && (
+                      <p style={{ marginTop: 8, color: '#2563eb' }}>Checking your available credits…</p>
+                    )}
+                  </div>
+                  {researchStatus === 'running' && (
+                    <div className="research-progress" role="status" aria-live="polite">
+                      <span className="research-progress__spinner" aria-hidden="true" />
+                      <div className="research-progress__content">
+                        <p>
+                          Gathering evidence — this may take several minutes, please be patient and have a cup of tea.
+                        </p>
+                        <p>We&apos;ll keep posting updates in the activity feed below while the research continues.</p>
+                      </div>
+                    </div>
+                  )}
+                  {researchStatus === 'running' && researchActivities.length > 0 && (
+                    <div style={{ marginTop: 12 }}>
+                      <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>Latest activity</h5>
+                      <ul style={{ paddingLeft: 18, margin: 0 }}>
+                        {researchActivities.map((activity) => (
+                          <li key={activity.id} style={{ marginBottom: 4 }}>
+                            {activity.text}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {(hasResearchContent || researchStatus === 'running') && (
+                    <div style={{ marginTop: 12 }}>
+                      <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>Research notes</h5>
+                      <div className="research-notes">
+                        {researchContent ? (
+                          <ReactMarkdown
+                            skipHtml
+                            components={{
+                              a: ({ node, ...props }) => (
+                                <a {...props} target="_blank" rel="noreferrer noopener" />
+                              ),
+                            }}
+                          >
+                            {researchContent}
+                          </ReactMarkdown>
+                        ) : (
+                          <p className="research-notes__placeholder">Collecting evidence…</p>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                  {researchResponseId && (
+                    <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#6b7280' }}>
+                      Research reference ID: {researchResponseId}
+                    </p>
+                  )}
+                </div>
+
+                <div
+                  style={{
+                    marginTop: 12,
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    alignItems: 'center',
+                    gap: 12,
+                  }}
+                >
+                  <button
+                    type="button"
+                    className="btn-link"
+                    onClick={() => setShowSummaryDetails((prev) => !prev)}
+                    disabled={loading}
+                  >
+                    {showSummaryDetails ? 'Hide intake details' : 'Show intake details'}
+                  </button>
+                  {responseId && !showSummaryDetails && (
+                    <span style={{ fontSize: '0.85rem', color: '#6b7280' }}>Reference ID: {responseId}</span>
+                  )}
+                </div>
+
+                {showSummaryDetails && (
+                  <>
+                    <div className="card" style={{ padding: 16, marginTop: 16 }}>
+                      <h4 className="section-title" style={{ fontSize: '1rem' }}>What you told us</h4>
+                      <div className="stack" style={{ marginTop: 12 }}>
+                        {steps.map((step) => (
+                          <div key={step.key} style={{ marginBottom: 16 }}>
+                            <div>
+                              <h5 style={{ margin: 0, fontWeight: 600, fontSize: '1rem' }}>{step.title}</h5>
+                            </div>
+                            <p style={{ margin: '6px 0 0 0' }}>{form[step.key]}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="card" style={{ padding: 16, marginTop: 16 }}>
+                      <h4 className="section-title" style={{ fontSize: '1rem' }}>Follow-up questions</h4>
+                      {followUps.length > 0 ? (
+                        <ol style={{ marginTop: 8, paddingLeft: 20 }}>
+                          {followUps.map((q, idx) => (
+                            <li key={idx} style={{ marginBottom: 12 }}>
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  alignItems: 'flex-start',
+                                  gap: 12,
+                                }}
+                              >
+                                <p style={{ marginBottom: 4 }}>{q}</p>
+                                <button
+                                  type="button"
+                                  className="btn-link"
+                                  onClick={() => handleEditFollowUpQuestion(idx)}
+                                  aria-label={`Edit answer for follow-up question ${idx + 1}`}
+                                  disabled={loading}
+                                >
+                                  Edit answer
+                                </button>
+                              </div>
+                              <p style={{ margin: 0, fontWeight: 600 }}>Your answer:</p>
+                              <p style={{ margin: '4px 0 0 0' }}>{followUpAnswers[idx]}</p>
+                            </li>
+                          ))}
+                        </ol>
+                      ) : (
+                        <p style={{ marginTop: 8 }}>No additional questions needed — we have enough detail for the next step.</p>
+                      )}
+                      {followUps.length > 0 && (
+                        <div className="actions" style={{ marginTop: 12 }}>
+                          <button
+                            type="button"
+                            className="btn-link"
+                            onClick={handleRegenerateFollowUps}
+                            disabled={loading}
+                          >
+                            Ask for new follow-up questions (costs {formatCredits(followUpCreditCost)} credits)
+                          </button>
+                        </div>
+                      )}
+                      {notes && <p style={{ marginTop: 8, fontStyle: 'italic' }}>{notes}</p>}
+                      {responseId && (
+                        <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#6b7280' }}>Reference ID: {responseId}</p>
+                      )}
+                    </div>
+                  </>
+                )}
+
+                <div
+                  className="actions"
+                  style={{ marginTop: 16, display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}
+                >
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={() => setStartOverConfirmOpen(true)}
+                    disabled={loading}
+                  >
+                    Start again
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={() => setEditIntakeModalOpen(true)}
+                    disabled={loading || researchStatus === 'running'}
+                  >
+                    Edit intake answers
+                  </button>
+                  {followUps.length > 0 && (
+                    <button
+                      type="button"
+                      className="btn-secondary"
+                      onClick={() => handleEditFollowUpQuestion(0)}
+                      disabled={loading || researchStatus === 'running'}
+                    >
+                      Review follow-up answers
+                    </button>
+                  )}
+                  {researchStatus === 'completed' && (
+                    <button
+                      type="button"
+                      className="btn-primary create-letter-button"
+                      onClick={handleShowToneSelection}
+                      disabled={loading}
+                    >
+                      Create my letter (costs {formatCredits(letterCreditCost)} credits)
+                    </button>
                   )}
                 </div>
               </>
             )}
 
-            <div
-              className="actions"
-              style={{ marginTop: 16, display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}
-            >
-              <button
-                type="button"
-                className="btn-secondary"
-                onClick={() => setStartOverConfirmOpen(true)}
-                disabled={loading}
-              >
-                Start again
-              </button>
-              <button
-                type="button"
-                className="btn-secondary"
-                onClick={() => setEditIntakeModalOpen(true)}
-                disabled={loading || researchStatus === 'running'}
-              >
-                Edit intake answers
-              </button>
-              {followUps.length > 0 && (
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => handleEditFollowUpQuestion(0)}
-                  disabled={loading || researchStatus === 'running'}
-                >
-                  Review follow-up answers
-                </button>
-              )}
-              {researchStatus === 'completed' && (
-                <button
-                  type="button"
-                  className="btn-primary create-letter-button"
-                  disabled={loading}
-                >
-                  Create my letter (costs {formatCredits(letterCreditCost)} credits)
-                </button>
-              )}
-            </div>
+            {letterPhase === 'tone' && (
+              <div className="card" style={{ padding: 16, marginTop: 16 }}>
+                <h4 className="section-title" style={{ fontSize: '1.1rem' }}>Choose a tone for your letter</h4>
+                <p className="section-sub">
+                  Pick the style you want the drafted MP letter to use. You can always compose another letter later in a different tone.
+                </p>
+                <div className="tone-grid" style={{ display: 'grid', gap: 12, marginTop: 16 }}>
+                  {WRITING_DESK_LETTER_TONES.map((tone) => {
+                    const toneInfo = LETTER_TONE_LABELS[tone];
+                    return (
+                      <button
+                        key={tone}
+                        type="button"
+                        className="tone-option"
+                        onClick={() => handleToneSelect(tone)}
+                      >
+                        <span className="tone-option__label">{toneInfo.label}</span>
+                        <span className="tone-option__description">{toneInfo.description}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="actions" style={{ marginTop: 16, display: 'flex', gap: 12 }}>
+                  <button type="button" className="btn-secondary" onClick={() => setLetterPhase('idle')}>
+                    Back to summary
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {letterPhase === 'streaming' && (
+              <div className="card" style={{ padding: 16, marginTop: 16 }}>
+                <h4 className="section-title" style={{ fontSize: '1.1rem' }}>Drafting your letter</h4>
+                {letterStatusMessage && <p style={{ marginTop: 8 }}>{letterStatusMessage}</p>}
+                {letterReasoningVisible && (
+                  <div style={{ marginTop: 16 }}>
+                    <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>Reasoning feed</h5>
+                    {letterEvents.length > 0 ? (
+                      <ul style={{ margin: 0, paddingLeft: 18 }}>
+                        {letterEvents.map((event) => (
+                          <li key={event.id} style={{ marginBottom: 4 }}>{event.text}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p style={{ margin: 0, color: '#6b7280' }}>The assistant is planning the letter…</p>
+                    )}
+                  </div>
+                )}
+                <div style={{ marginTop: 16 }}>
+                  <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>Letter preview</h5>
+                  <div
+                    className="letter-preview"
+                    dangerouslySetInnerHTML={{ __html: letterContentHtml || '<p>Drafting the opening paragraph…</p>' }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {letterPhase === 'completed' && letterMetadata && (
+              <div className="card" style={{ padding: 16, marginTop: 16 }}>
+                <h4 className="section-title" style={{ fontSize: '1.1rem' }}>Your drafted letter</h4>
+                <p className="section-sub">
+                  Tone: {selectedTone ? LETTER_TONE_LABELS[selectedTone].label : 'Not specified'} · Date {letterMetadata.date || new Date().toISOString().slice(0, 10)}
+                </p>
+                {letterResponseId && (
+                  <p style={{ marginTop: 4, fontSize: '0.85rem', color: '#6b7280' }}>Letter reference ID: {letterResponseId}</p>
+                )}
+                <div
+                  className="letter-preview"
+                  style={{ marginTop: 16 }}
+                  dangerouslySetInnerHTML={{ __html: letterContentHtml || '<p>No content available.</p>' }}
+                />
+                <div className="actions" style={{ marginTop: 16, display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+                  <button type="button" className="btn-primary" onClick={handleCopyLetter}>
+                    {letterCopyState === 'copied' ? 'Copied!' : letterCopyState === 'error' ? 'Copy failed — try again' : 'Copy letter as HTML'}
+                  </button>
+                  <button type="button" className="btn-secondary" onClick={handleShowToneSelection}>
+                    Compose another letter
+                  </button>
+                </div>
+                <div style={{ marginTop: 16 }}>
+                  <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>Addresses</h5>
+                  <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))' }}>
+                    <div>
+                      <strong>MP</strong>
+                      <p style={{ margin: '4px 0 0 0' }}>
+                        {letterMetadata.mpName}
+                        <br />
+                        {[letterMetadata.mpAddress1, letterMetadata.mpAddress2, letterMetadata.mpCity, letterMetadata.mpCounty]
+                          .filter(Boolean)
+                          .join(', ')}
+                        <br />
+                        {letterMetadata.mpPostcode}
+                      </p>
+                    </div>
+                    <div>
+                      <strong>Sender</strong>
+                      <p style={{ margin: '4px 0 0 0' }}>
+                        {letterMetadata.senderName}
+                        <br />
+                        {[letterMetadata.senderAddress1, letterMetadata.senderAddress2, letterMetadata.senderAddress3, letterMetadata.senderCity, letterMetadata.senderCounty]
+                          .filter(Boolean)
+                          .join(', ')}
+                        <br />
+                        {letterMetadata.senderPostcode}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                {letterMetadata.references && letterMetadata.references.length > 0 && (
+                  <div style={{ marginTop: 16 }}>
+                    <h5 style={{ margin: '0 0 8px 0', fontSize: '0.95rem' }}>References</h5>
+                    <ul style={{ paddingLeft: 18, margin: 0 }}>
+                      {letterMetadata.references.map((ref, index) => (
+                        <li key={`${ref}-${index}`} style={{ marginBottom: 4 }}>
+                          <a href={ref} target="_blank" rel="noreferrer noopener">
+                            {ref}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {letterPhase === 'error' && (
+              <div className="card" style={{ padding: 16, marginTop: 16 }}>
+                <h4 className="section-title" style={{ fontSize: '1.1rem', color: '#b91c1c' }}>We couldn&apos;t finish your letter</h4>
+                {letterError && <p style={{ marginTop: 8 }}>{letterError}</p>}
+                <div className="actions" style={{ marginTop: 16, display: 'flex', gap: 12 }}>
+                  <button type="button" className="btn-primary" onClick={handleShowToneSelection}>
+                    Try again
+                  </button>
+                  <button type="button" className="btn-secondary" onClick={() => setLetterPhase('idle')}>
+                    Back to summary
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/features/writing-desk/api/letter.ts
+++ b/frontend/src/features/writing-desk/api/letter.ts
@@ -1,0 +1,30 @@
+import { WritingDeskLetterTone } from '../types';
+
+export interface StartLetterResponse {
+  jobId: string;
+  streamPath: string;
+}
+
+export async function startLetterComposition(input: {
+  jobId?: string;
+  tone: WritingDeskLetterTone;
+}): Promise<StartLetterResponse> {
+  const res = await fetch('/api/writing-desk/jobs/active/letter/start', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jobId: input.jobId, tone: input.tone }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Request failed (${res.status})`);
+  }
+
+  const data = (await res.json().catch(() => null)) as StartLetterResponse | null;
+  if (!data || typeof data.jobId !== 'string' || typeof data.streamPath !== 'string') {
+    throw new Error('We could not start letter composition. Please try again.');
+  }
+
+  return data;
+}

--- a/frontend/src/features/writing-desk/types.ts
+++ b/frontend/src/features/writing-desk/types.ts
@@ -6,6 +6,20 @@ export const WRITING_DESK_RESEARCH_STATUSES = ['idle', 'running', 'completed', '
 
 export type WritingDeskResearchStatus = (typeof WRITING_DESK_RESEARCH_STATUSES)[number];
 
+export const WRITING_DESK_LETTER_STATUSES = ['idle', 'generating', 'completed', 'error'] as const;
+
+export type WritingDeskLetterStatus = (typeof WRITING_DESK_LETTER_STATUSES)[number];
+
+export const WRITING_DESK_LETTER_TONES = [
+  'formal',
+  'polite_but_firm',
+  'empathetic',
+  'urgent',
+  'neutral',
+] as const;
+
+export type WritingDeskLetterTone = (typeof WRITING_DESK_LETTER_TONES)[number];
+
 export interface WritingDeskJobFormSnapshot {
   issueDescription: string;
 }
@@ -23,6 +37,12 @@ export interface ActiveWritingDeskJob {
   researchContent: string | null;
   researchResponseId: string | null;
   researchStatus: WritingDeskResearchStatus;
+  letterStatus: WritingDeskLetterStatus;
+  letterTone: WritingDeskLetterTone | null;
+  letterResponseId: string | null;
+  letterContent: string | null;
+  letterReferences: string[];
+  letterJson: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -40,4 +60,10 @@ export interface UpsertActiveWritingDeskJobPayload {
   researchContent?: string | null;
   researchResponseId?: string | null;
   researchStatus?: WritingDeskResearchStatus;
+  letterStatus?: WritingDeskLetterStatus;
+  letterTone?: WritingDeskLetterTone | null;
+  letterResponseId?: string | null;
+  letterContent?: string | null;
+  letterReferences?: string[];
+  letterJson?: string | null;
 }

--- a/frontend/src/features/writing-desk/utils/composeLetterHtml.ts
+++ b/frontend/src/features/writing-desk/utils/composeLetterHtml.ts
@@ -1,0 +1,170 @@
+export interface LetterRenderInput {
+  mpName?: string | null;
+  mpAddress1?: string | null;
+  mpAddress2?: string | null;
+  mpCity?: string | null;
+  mpCounty?: string | null;
+  mpPostcode?: string | null;
+  date?: string | null;
+  letterContentHtml?: string | null;
+  senderName?: string | null;
+  senderAddress1?: string | null;
+  senderAddress2?: string | null;
+  senderAddress3?: string | null;
+  senderCity?: string | null;
+  senderCounty?: string | null;
+  senderPostcode?: string | null;
+  references?: string[] | null;
+}
+
+export const composeLetterHtml = (input: LetterRenderInput): string => {
+  const sections: string[] = [];
+  const mpLines = buildAddressLines({
+    name: input.mpName,
+    line1: input.mpAddress1,
+    line2: input.mpAddress2,
+    line3: null,
+    city: input.mpCity,
+    county: input.mpCounty,
+    postcode: input.mpPostcode,
+  });
+
+  if (mpLines.length > 0) {
+    sections.push(`<p>${mpLines.map(escapeHtml).join('<br />')}</p>`);
+  }
+
+  const formattedDate = formatDisplayDate(input.date);
+  if (formattedDate) {
+    sections.push(`<p>${escapeHtml(formattedDate)}</p>`);
+  }
+
+  if (input.letterContentHtml) {
+    sections.push(input.letterContentHtml);
+  }
+
+  const senderLines = buildAddressLines({
+    name: input.senderName,
+    line1: input.senderAddress1,
+    line2: input.senderAddress2,
+    line3: input.senderAddress3,
+    city: input.senderCity,
+    county: input.senderCounty,
+    postcode: input.senderPostcode,
+  });
+
+  const hasAddressDetail = senderLines.slice(1).some((line) => line.trim().length > 0);
+  if (hasAddressDetail && shouldAppendSenderAddress(input.letterContentHtml ?? '', senderLines)) {
+    sections.push(`<p>${senderLines.map(escapeHtml).join('<br />')}</p>`);
+  }
+
+  const references = Array.isArray(input.references)
+    ? input.references.filter((ref): ref is string => typeof ref === 'string' && ref.trim().length > 0)
+    : [];
+
+  if (references.length > 0) {
+    sections.push('<p><strong>References</strong></p>');
+    sections.push(
+      `<ul>${references
+        .map((ref) => {
+          const trimmed = ref.trim();
+          if (!trimmed) return '';
+          const escaped = escapeHtml(trimmed);
+          return `<li><a href="${escaped}" target="_blank" rel="noreferrer noopener">${escaped}</a></li>`;
+        })
+        .filter((entry) => entry.length > 0)
+        .join('')}</ul>`,
+    );
+  }
+
+  return sections.join('');
+};
+
+export const letterHtmlToPlainText = (value: string): string => normalisePlainText(value);
+
+const buildAddressLines = (input: {
+  name?: string | null;
+  line1?: string | null;
+  line2?: string | null;
+  line3?: string | null;
+  city?: string | null;
+  county?: string | null;
+  postcode?: string | null;
+}): string[] => {
+  const lines: string[] = [];
+  const push = (raw?: string | null) => {
+    if (typeof raw !== 'string') return;
+    const trimmed = raw.trim();
+    if (trimmed.length > 0) {
+      lines.push(trimmed);
+    }
+  };
+
+  push(input.name);
+  push(input.line1);
+  push(input.line2);
+  push(input.line3);
+
+  const city = typeof input.city === 'string' ? input.city.trim() : '';
+  const county = typeof input.county === 'string' ? input.county.trim() : '';
+  const postcode = typeof input.postcode === 'string' ? input.postcode.trim() : '';
+  const locality = [city, county].filter((part) => part.length > 0).join(', ');
+
+  if (locality && postcode) {
+    lines.push(`${locality} ${postcode}`.trim());
+  } else if (locality) {
+    lines.push(locality);
+  } else if (postcode) {
+    lines.push(postcode);
+  }
+
+  return lines;
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const formatDisplayDate = (value: string | null | undefined): string => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+  const [year, month, day] = trimmed.split('-');
+  if (!year || !month || !day) return trimmed;
+  return `${day}/${month}/${year}`;
+};
+
+const shouldAppendSenderAddress = (letterHtml: string, senderLines: string[]): boolean => {
+  if (senderLines.length === 0) return false;
+  const addressDetail = senderLines.slice(1).filter((line) => line.trim().length > 0);
+  if (addressDetail.length === 0) return false;
+  const text = normalisePlainText(letterHtml);
+  if (!text) return true;
+  const lower = text.toLowerCase();
+  const name = senderLines[0]?.trim()?.toLowerCase();
+  const hasName = name ? lower.includes(name) : false;
+  const hasAddress = addressDetail.some((line) => lower.includes(line.trim().toLowerCase()));
+  return !(hasName && hasAddress);
+};
+
+const normalisePlainText = (value: string | null | undefined): string => {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/<br\s*\/?\s*>/gi, '\n')
+    .replace(/<\/(p|div|h\d)>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+};


### PR DESCRIPTION
## Summary
- add schema-driven MP letter composition service with tone-specific prompt handling and improved stub output
- expose letter streaming endpoint and persistence wiring alongside frontend tone selection and streaming UI updates

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68db96fc9b9c83218bccaff7fae95ee0