### PR TITLE
Add highly persuasive letter tone

### DIFF
--- a/backend-api/src/ai/ai.service.ts
+++ b/backend-api/src/ai/ai.service.ts
@@ -277,6 +277,11 @@ const LETTER_TONE_DETAILS: Record<WritingDeskLetterTone, { label: string; prompt
     prompt:
       'Use clear, matter-of-fact language that presents evidence and requests without emotional colouring.',
   },
+  highly_persuasive: {
+    label: 'Highly persuasive',
+    prompt:
+      'Craft a confident, compelling argument that highlights benefits, anticipated outcomes, and stakes while remaining respectful and evidence-led.',
+  },
 };
 
 const LETTER_TONE_SIGN_OFFS: Record<WritingDeskLetterTone, string> = {
@@ -285,6 +290,7 @@ const LETTER_TONE_SIGN_OFFS: Record<WritingDeskLetterTone, string> = {
   empathetic: 'With thanks for your understanding,',
   urgent: 'Yours urgently,',
   neutral: 'Yours sincerely,',
+  highly_persuasive: 'With determination,',
 };
 
 const LETTER_TONE_REQUEST_PREFIX: Record<WritingDeskLetterTone, string> = {
@@ -293,6 +299,7 @@ const LETTER_TONE_REQUEST_PREFIX: Record<WritingDeskLetterTone, string> = {
   empathetic: 'I kindly ask that you',
   urgent: 'Please urgently',
   neutral: 'I ask that you',
+  highly_persuasive: 'I strongly urge you to',
 };
 
 const LETTER_SYSTEM_PROMPT = `You are generating a UK MP letter using stored MP and sender details plus prior user inputs.

--- a/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
+++ b/backend-api/src/writing-desk-jobs/writing-desk-jobs.types.ts
@@ -16,6 +16,7 @@ export const WRITING_DESK_LETTER_TONES = [
   'empathetic',
   'urgent',
   'neutral',
+  'highly_persuasive',
 ] as const;
 
 export type WritingDeskLetterTone = (typeof WRITING_DESK_LETTER_TONES)[number];

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -69,6 +69,11 @@ const LETTER_TONE_LABELS: Record<
     description: 'Calm, factual tone that lets the evidence speak for itself.',
     icon: '📄',
   },
+  highly_persuasive: {
+    label: 'Highly persuasive',
+    description: 'Confident, evidence-led case designed to motivate decisive action.',
+    icon: '🎯',
+  },
 };
 
 type ResearchStatus = 'idle' | 'running' | 'completed' | 'error';
@@ -2161,6 +2166,15 @@ export default function WritingDeskClient() {
           --tone-text: rgba(51, 65, 85, 0.88);
           --tone-badge-bg: rgba(71, 85, 105, 0.18);
           --tone-badge-fg: #1e293b;
+        }
+
+        .tone-option[data-tone='highly_persuasive'] {
+          --tone-bg: linear-gradient(135deg, #ecfeff 0%, #cffafe 100%);
+          --tone-border: rgba(14, 165, 233, 0.38);
+          --tone-heading: #0f766e;
+          --tone-text: rgba(15, 118, 110, 0.9);
+          --tone-badge-bg: rgba(13, 148, 136, 0.18);
+          --tone-badge-fg: #115e59;
         }
 
         @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/features/writing-desk/types.ts
+++ b/frontend/src/features/writing-desk/types.ts
@@ -16,6 +16,7 @@ export const WRITING_DESK_LETTER_TONES = [
   'empathetic',
   'urgent',
   'neutral',
+  'highly_persuasive',
 ] as const;
 
 export type WritingDeskLetterTone = (typeof WRITING_DESK_LETTER_TONES)[number];


### PR DESCRIPTION
## Summary
- add a highly persuasive tone option to the writing desk types shared by the backend and frontend
- extend AI tone prompts, sign-offs, and request phrasing to support the new tone
- expose the tone in the UI with dedicated copy, icon, and styling

## Testing
- CI=1 npx nx test frontend --runInBand *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68ded4e0d1f48321af874deb190b7e36