### PR TITLE
Add credit shop page and navigation

### DIFF
--- a/frontend/src/app/credit-shop/page.tsx
+++ b/frontend/src/app/credit-shop/page.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+type CreditState = {
+  credits: number | null;
+  status: 'idle' | 'loading' | 'success' | 'error';
+  message: string | null;
+};
+
+const DEAL_AMOUNT = 5;
+const DEAL_PRICE = 3.99;
+
+const currencyFormatter = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' });
+
+export default function CreditShopPage() {
+  const [state, setState] = useState<CreditState>({ credits: null, status: 'idle', message: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/user/credits', { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && typeof data?.credits === 'number') {
+          setState((prev) => ({ ...prev, credits: data.credits }));
+        }
+      } catch {
+        // Ignore fetch errors silently, page will still allow purchase attempts.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handlePurchase = async () => {
+    setState((prev) => ({ ...prev, status: 'loading', message: null }));
+    try {
+      const res = await fetch('/api/user/credits/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: DEAL_AMOUNT }),
+      });
+      if (!res.ok) {
+        setState((prev) => ({
+          ...prev,
+          status: 'error',
+          message: 'Unable to complete your purchase right now. Please try again shortly.',
+        }));
+        return;
+      }
+      const data = await res.json();
+      const credits = typeof data?.credits === 'number' ? data.credits : prevCreditsAfterPurchase(state.credits, DEAL_AMOUNT);
+      setState({
+        credits,
+        status: 'success',
+        message: `Success! ${DEAL_AMOUNT} credits have been added to your account.`,
+      });
+    } catch {
+      setState((prev) => ({
+        ...prev,
+        status: 'error',
+        message: 'Unable to complete your purchase right now. Please try again shortly.',
+      }));
+    }
+  };
+
+  const buttonLabel = state.status === 'loading' ? 'Processing purchase…' : `Buy now for ${currencyFormatter.format(DEAL_PRICE)}`;
+
+  return (
+    <main className="hero-section">
+      <section className="card">
+        <div className="container" style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+          <header>
+            <h1 className="section-title">Credit shop</h1>
+            <p>Purchase additional credits to continue crafting powerful letters to your MP.</p>
+          </header>
+          <div className="card" style={{ background: '#f8fafc', border: '1px solid #e2e8f0' }}>
+            <div className="container" style={{ display: 'flex', flexDirection: 'column', gap: 16, alignItems: 'flex-start' }}>
+              <p style={{ textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, color: '#2563eb' }}>Today&apos;s deal</p>
+              <h2 style={{ fontSize: '1.75rem', margin: 0 }}>
+                {DEAL_AMOUNT} credits for {currencyFormatter.format(DEAL_PRICE)}
+              </h2>
+              <p style={{ margin: 0, fontSize: '1.125rem' }}>Top up instantly and keep writing.</p>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={handlePurchase}
+                disabled={state.status === 'loading'}
+                style={{ minWidth: 200 }}
+              >
+                {buttonLabel}
+              </button>
+              {state.message && (
+                <p
+                  role={state.status === 'error' ? 'alert' : undefined}
+                  style={{
+                    margin: 0,
+                    color: state.status === 'error' ? '#b91c1c' : '#166534',
+                    fontWeight: 500,
+                  }}
+                >
+                  {state.message}
+                </p>
+              )}
+              {typeof state.credits === 'number' && (
+                <p style={{ margin: 0 }}>You now have {formatCredits(state.credits)} credits available.</p>
+              )}
+            </div>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 12 }}>
+            <Link href="/dashboard" className="btn-secondary">
+              Exit shop
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function prevCreditsAfterPurchase(current: number | null, delta: number) {
+  if (typeof current !== 'number') return delta;
+  return Math.round((current + delta) * 100) / 100;
+}
+
+function formatCredits(value: number) {
+  return value.toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -34,28 +34,11 @@ export default function DashboardPage() {
     };
   }, []);
 
-  async function handleCreditShopClick() {
-    if (!demoPurchasesEnabled) return;
-    try {
-      const res = await fetch('/api/user/credits/add', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amount: 1 }),
-      });
-      if (!res.ok) return;
-      const data = await res.json();
-      if (typeof data?.credits === 'number') setCredits(data.credits);
-    } catch {
-      // ignore temporary demo errors
-    }
-  }
-
   return (
     <main className="hero-section">
       <DashboardWelcome
         firstName={firstName}
         credits={credits}
-        onAddCredit={demoPurchasesEnabled ? handleCreditShopClick : undefined}
         demoPurchasesEnabled={demoPurchasesEnabled}
       />
       <section className="card" style={{ marginTop: 16 }}>

--- a/frontend/src/components/DashboardWelcome.tsx
+++ b/frontend/src/components/DashboardWelcome.tsx
@@ -1,16 +1,15 @@
 "use client";
 
+import Link from 'next/link';
+
 type Props = {
   firstName: string;
   credits: number;
-  onAddCredit?: () => void;
   demoPurchasesEnabled?: boolean;
 };
 
-export default function DashboardWelcome({ firstName, credits, onAddCredit, demoPurchasesEnabled }: Props) {
-  const pricePence = Number(process.env.NEXT_PUBLIC_CREDIT_PRICE_PENCE ?? '500');
-  const priceText = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format((pricePence || 500) / 100);
-  const showPurchase = (demoPurchasesEnabled ?? true) && typeof onAddCredit === 'function';
+export default function DashboardWelcome({ firstName, credits, demoPurchasesEnabled }: Props) {
+  const showCreditShop = demoPurchasesEnabled ?? true;
   const formatCredits = (value: number) => {
     const rounded = Math.round(value * 100) / 100;
     return rounded.toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');
@@ -25,10 +24,10 @@ export default function DashboardWelcome({ firstName, credits, onAddCredit, demo
           <p><em className="fineprint">(Saved addresses are encrypted and can only be read by you.)</em></p>
         </div>
         <div className="credits-info">
-          {showPurchase && (
-            <button type="button" className="btn-primary btn-wide" onClick={onAddCredit}>
-              Buy 1 credit ({priceText})
-            </button>
+          {showCreditShop && (
+            <Link className="btn-primary btn-wide" href="/credit-shop">
+              Visit credit shop
+            </Link>
           )}
           <div className="credit-balance" aria-label={`You have ${formatCredits(credits)} credits available`}>
             <svg


### PR DESCRIPTION
## Summary
- replace the dashboard credit purchase button with navigation to the new credit shop
- add a credit shop page that offers 5 credits for £3.99 and calls the credit API when purchasing
- include an exit shop link that returns users to their dashboard after browsing the deal

## Testing
- CI=1 npx nx test frontend --output-style=stream *(fails: existing Jest config cannot parse ESM from react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a3f125d4832198aa4e95e8fb451b