### PR TITLE
Add telephone support to saved addresses and letters

### DIFF
--- a/backend-api/src/ai/ai.service.ts
+++ b/backend-api/src/ai/ai.service.ts
@@ -100,6 +100,7 @@ interface WritingDeskLetterResult {
   sender_city: string;
   sender_county: string;
   sender_postcode: string;
+  sender_phone: string;
   references: string[];
 }
 
@@ -120,6 +121,7 @@ interface LetterCompletePayload {
   senderCity: string;
   senderCounty: string;
   senderPostcode: string;
+  senderTelephone: string;
   references: string[];
   responseId: string | null;
   tone: WritingDeskLetterTone;
@@ -159,6 +161,7 @@ interface LetterDocumentInput {
   senderCity?: string | null;
   senderCounty?: string | null;
   senderPostcode?: string | null;
+  senderTelephone?: string | null;
   references?: string[] | null;
 }
 
@@ -177,6 +180,7 @@ interface LetterContext {
   senderCity: string;
   senderCounty: string;
   senderPostcode: string;
+  senderTelephone: string;
   today: string;
 }
 
@@ -249,6 +253,10 @@ const LETTER_RESPONSE_SCHEMA = {
       type: 'string',
       description: "Post code of the sender's address.",
     },
+    sender_phone: {
+      type: 'string',
+      description: "Telephone number for the sender, shown beneath the postal address.",
+    },
     references: {
       type: 'array',
       description: 'List of full, properly formatted URLs used as references. URLs must be complete with protocol (https://) and should NOT be percent-encoded - use plain characters for special symbols like #, :, ~, and = in URL fragments.',
@@ -275,6 +283,7 @@ const LETTER_RESPONSE_SCHEMA = {
     'sender_city',
     'sender_county',
     'sender_postcode',
+    'sender_phone',
     'references',
   ],
   additionalProperties: false,
@@ -833,6 +842,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
           senderCity: stub.sender_city,
           senderCounty: stub.sender_county,
           senderPostcode: stub.sender_postcode,
+          senderTelephone: stub.sender_phone,
           references: stub.references,
         });
         const rawJson = JSON.stringify(stub);
@@ -914,13 +924,14 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
                 letterContentHtml: preview,
                 senderName: context.senderName,
                 senderAddress1: context.senderAddress1,
-                senderAddress2: context.senderAddress2,
-                senderAddress3: context.senderAddress3,
-                senderCity: context.senderCity,
-                senderCounty: context.senderCounty,
-                senderPostcode: context.senderPostcode,
-                references: this.extractReferencesFromJson(jsonBuffer),
-              });
+              senderAddress2: context.senderAddress2,
+              senderAddress3: context.senderAddress3,
+              senderCity: context.senderCity,
+              senderCounty: context.senderCounty,
+              senderPostcode: context.senderPostcode,
+              senderTelephone: context.senderTelephone,
+              references: this.extractReferencesFromJson(jsonBuffer),
+            });
               send({ type: 'letter_delta', html: previewDocument });
             }
           }
@@ -948,6 +959,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
               senderCity: context.senderCity,
               senderCounty: context.senderCounty,
               senderPostcode: context.senderPostcode,
+              senderTelephone: context.senderTelephone,
               references: this.extractReferencesFromJson(jsonBuffer),
             });
             send({ type: 'letter_delta', html: previewDocument });
@@ -998,6 +1010,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
             senderCity: merged.sender_city,
             senderCounty: merged.sender_county,
             senderPostcode: merged.sender_postcode,
+            senderTelephone: merged.sender_phone,
             references,
           });
 
@@ -2018,6 +2031,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
     const senderCity = typeof senderAddress?.city === 'string' ? senderAddress.city : '';
     const senderCounty = typeof senderAddress?.county === 'string' ? senderAddress.county : '';
     const senderPostcode = typeof senderAddress?.postcode === 'string' ? senderAddress.postcode : '';
+    const senderTelephone = typeof senderAddress?.telephone === 'string' ? senderAddress.telephone : '';
 
     const mpName =
       typeof (mpRecord as any)?.mp?.name === 'string' && (mpRecord as any).mp.name.trim().length > 0
@@ -2047,6 +2061,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
       senderCity,
       senderCounty,
       senderPostcode,
+      senderTelephone,
       today,
     };
   }
@@ -2080,6 +2095,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
       `Today's date: ${context.today}`,
       `MP profile:\n- Name: ${context.mpName || 'Unknown'}\n- Constituency: ${context.constituency || 'Unknown'}\n- Parliamentary address line 1: ${context.mpAddress1 || ''}\n- Parliamentary address line 2: ${context.mpAddress2 || ''}\n- Parliamentary city: ${context.mpCity || ''}\n- Parliamentary county: ${context.mpCounty || ''}\n- Parliamentary postcode: ${context.mpPostcode || ''}`,
       `Sender profile:\n- Name: ${context.senderName || ''}\n- Address line 1: ${context.senderAddress1 || ''}\n- Address line 2: ${context.senderAddress2 || ''}\n- Address line 3: ${context.senderAddress3 || ''}\n- City: ${context.senderCity || ''}\n- County: ${context.senderCounty || ''}\n- Postcode: ${context.senderPostcode || ''}`,
+      `Sender profile:\n- Name: ${context.senderName || ''}\n- Address line 1: ${context.senderAddress1 || ''}\n- Address line 2: ${context.senderAddress2 || ''}\n- Address line 3: ${context.senderAddress3 || ''}\n- City: ${context.senderCity || ''}\n- County: ${context.senderCounty || ''}\n- Postcode: ${context.senderPostcode || ''}\n- Telephone: ${context.senderTelephone || ''}`,
       `User intake description:\n${intake}`,
       `Follow-up details:\n${followUpSection}`,
       `Deep research findings:\n${researchSection}`,
@@ -2113,6 +2129,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
     schema.properties.sender_city.const = normalise(context.senderCity);
     schema.properties.sender_county.const = normalise(context.senderCounty);
     schema.properties.sender_postcode.const = normalise(context.senderPostcode);
+    schema.properties.sender_phone.const = normalise(context.senderTelephone);
 
     return schema;
   }
@@ -2245,6 +2262,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
       sender_city: context.senderCity || '',
       sender_county: context.senderCounty || '',
       sender_postcode: context.senderPostcode || '',
+      sender_phone: context.senderTelephone || '',
       references: [],
     };
   }
@@ -2296,6 +2314,11 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
     const hasAddressDetail = senderLines.some((line) => line.trim().length > 0);
     if (hasAddressDetail && this.shouldAppendSenderAddress(letterContentHtml, senderLines, senderName)) {
       sections.push(`<p>${senderLines.map((line) => this.escapeLetterHtml(line)).join('<br />')}</p>`);
+    }
+
+    const telephone = normalise(input.senderTelephone).trim();
+    if (telephone.length > 0) {
+      sections.push(`<p>Tel: ${this.escapeLetterHtml(telephone)}</p>`);
     }
 
     const references = Array.isArray(input.references)
@@ -2455,6 +2478,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
       senderCity: result.sender_city ?? '',
       senderCounty: result.sender_county ?? '',
       senderPostcode: result.sender_postcode ?? '',
+      senderTelephone: result.sender_phone ?? '',
       references: Array.isArray(result.references) ? result.references : [],
       responseId: extras.responseId ?? null,
       tone: extras.tone,
@@ -2485,6 +2509,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
         sender_city: parsed.sender_city ?? '',
         sender_county: parsed.sender_county ?? '',
         sender_postcode: parsed.sender_postcode ?? '',
+        sender_phone: parsed.sender_phone ?? '',
         references: Array.isArray(parsed.references) ? parsed.references : [],
       });
     } catch (error) {
@@ -2517,6 +2542,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
       sender_city: normalise(context.senderCity),
       sender_county: normalise(context.senderCounty),
       sender_postcode: normalise(context.senderPostcode),
+      sender_phone: normalise(context.senderTelephone),
     });
   }
 
@@ -2641,6 +2667,7 @@ Do NOT ask for documents, permissions, names, addresses, or personal details. On
       sender_city: normalise(result.sender_city),
       sender_county: normalise(result.sender_county),
       sender_postcode: normalise(result.sender_postcode),
+      sender_phone: normalise(result.sender_phone),
       references: Array.isArray(result.references)
         ? result.references
             .map((value) => (typeof value === 'string' ? this.normaliseLetterTypography(value) : ''))

--- a/backend-api/src/user-address-store/dto/upsert-user-address.dto.ts
+++ b/backend-api/src/user-address-store/dto/upsert-user-address.dto.ts
@@ -25,5 +25,10 @@ export class UpsertUserAddressDto {
   @IsNotEmpty()
   @MaxLength(16)
   postcode!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(40)
+  telephone?: string;
 }
 

--- a/backend-api/src/user-address-store/user-address.service.ts
+++ b/backend-api/src/user-address-store/user-address.service.ts
@@ -21,21 +21,33 @@ export class UserAddressService {
     const doc = await this.model.findOne({ user: userId }).lean();
     if (!doc) return { address: null };
     try {
-      const address = this.enc.decryptObject<any>(doc.ciphertext);
-      return { address };
+      const address = this.enc.decryptObject<any>(doc.ciphertext) ?? {};
+      const normalised = {
+        line1: typeof address.line1 === 'string' ? address.line1 : '',
+        line2: typeof address.line2 === 'string' ? address.line2 : '',
+        city: typeof address.city === 'string' ? address.city : '',
+        county: typeof address.county === 'string' ? address.county : '',
+        postcode: typeof address.postcode === 'string' ? address.postcode : '',
+        telephone: typeof address.telephone === 'string' ? address.telephone : '',
+      };
+      return { address: normalised };
     } catch (e) {
       // If decryption fails, treat as no data (could also surface an error)
       return { address: null };
     }
   }
 
-  async upsertMine(userId: string, input: { line1: string; line2?: string; city?: string; county?: string; postcode: string }) {
+  async upsertMine(
+    userId: string,
+    input: { line1: string; line2?: string; city?: string; county?: string; postcode: string; telephone?: string },
+  ) {
     const payload = {
       line1: input.line1?.trim?.() || '',
       line2: input.line2?.trim?.() || '',
       city: input.city?.trim?.() || '',
       county: input.county?.trim?.() || '',
       postcode: normalisePostcode(input.postcode || ''),
+      telephone: input.telephone?.trim?.() || '',
     };
     const ciphertext = this.enc.encryptObject(payload);
     await this.model.updateOne(

--- a/frontend/src/app/global.css
+++ b/frontend/src/app/global.css
@@ -792,6 +792,8 @@ body {
   display: block;
   width: 100%;
   height: auto;
+  border-radius: 50%;
+  object-fit: cover;
 }
 
 .hero-title {
@@ -856,11 +858,13 @@ body {
   }
   .hero-graphic {
     display: block;
+    margin-left: auto;
+    max-width: 420px;
+    aspect-ratio: 1 / 1;
   }
   .hero-graphic img {
     width: 100%;
-    max-width: 420px;
-    margin-left: auto;
+    height: 100%;
   }
   .stepper {
     padding: 20px;

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -116,6 +116,7 @@ interface LetterStreamLetterPayload {
   senderCity: string;
   senderCounty: string;
   senderPostcode: string;
+  senderTelephone: string;
   references: string[];
   responseId: string | null;
   tone: WritingDeskLetterTone | null;
@@ -954,6 +955,7 @@ export default function WritingDeskClient() {
             senderCity: parsed.sender_city ?? '',
             senderCounty: parsed.sender_county ?? '',
             senderPostcode: parsed.sender_postcode ?? '',
+            senderTelephone: parsed.sender_phone ?? '',
             references: parsedReferences,
           });
           setLetterMetadata({
@@ -972,6 +974,7 @@ export default function WritingDeskClient() {
             senderCity: parsed.sender_city ?? '',
             senderCounty: parsed.sender_county ?? '',
             senderPostcode: parsed.sender_postcode ?? '',
+            senderTelephone: parsed.sender_phone ?? '',
             references: parsedReferences,
             responseId: job.letterResponseId ?? null,
             tone: job.letterTone ?? null,

--- a/frontend/src/components/DashboardWelcome.tsx
+++ b/frontend/src/components/DashboardWelcome.tsx
@@ -19,7 +19,11 @@ export default function DashboardWelcome({ firstName, credits }: Props) {
           <h2 className="section-title">Welcome to your dashboard {firstName}!</h2>
           <p>Please enter your postcode below to locate your MP and select your address.</p>
           <p>Then you are ready to write your letter!</p>
-          <p><em className="fineprint">(Saved addresses are encrypted and can only be read by you.)</em></p>
+          <p>
+            <em className="fineprint">
+              (Saved addresses and telephone numbers are encrypted so only you can read them. Singularity Shift Ltd does not access or use these details.)
+            </em>
+          </p>
         </div>
         <div className="credits-info">
           <Link className="btn-primary btn-wide" href="/credit-shop">

--- a/frontend/src/components/DashboardWelcome.tsx
+++ b/frontend/src/components/DashboardWelcome.tsx
@@ -27,7 +27,7 @@ export default function DashboardWelcome({ firstName, credits }: Props) {
         </div>
         <div className="credits-info">
           <Link className="btn-primary btn-wide" href="/credit-shop">
-            Visit credit shop
+            Credit shop
           </Link>
           <div className="credit-balance" aria-label={`You have ${formatCredits(credits)} credits available`}>
             <svg

--- a/frontend/src/features/writing-desk/utils/composeLetterHtml.ts
+++ b/frontend/src/features/writing-desk/utils/composeLetterHtml.ts
@@ -14,6 +14,7 @@ export interface LetterRenderInput {
   senderCity?: string | null;
   senderCounty?: string | null;
   senderPostcode?: string | null;
+  senderTelephone?: string | null;
   references?: string[] | null;
 }
 
@@ -56,6 +57,11 @@ export const composeLetterHtml = (input: LetterRenderInput): string => {
   const hasAddressDetail = senderLines.some((line) => line.trim().length > 0);
   if (hasAddressDetail && shouldAppendSenderAddress(input.letterContentHtml ?? '', senderLines, senderName)) {
     sections.push(`<p>${senderLines.map(escapeHtml).join('<br />')}</p>`);
+  }
+
+  const senderTelephone = typeof input.senderTelephone === 'string' ? input.senderTelephone.trim() : '';
+  if (senderTelephone.length > 0) {
+    sections.push(`<p>Tel: ${escapeHtml(senderTelephone)}</p>`);
   }
 
   const references = Array.isArray(input.references)


### PR DESCRIPTION
## Summary
- collect a telephone number alongside the saved address, including UI copy that clarifies Singularity Shift Ltd does not access the encrypted details
- persist the telephone field in the encrypted user address record and propagate it through the letter generation schema and context
- render the telephone number beneath the sender address in generated letters and previews so it appears before the references section

## Testing
- npx nx lint frontend *(fails: Cannot find configuration for task frontend:lint)*
- npx nx lint backend-api *(fails: Cannot find configuration for task backend-api:lint)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a0ccf4ac8321aec3a2dd15cfcb61