### PR TITLE
Add My Letters buttons to writing desk UI

### DIFF
--- a/frontend/src/app/global.css
+++ b/frontend/src/app/global.css
@@ -1413,6 +1413,13 @@ body {
   padding: 0;
 }
 
+.start-writing-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
 .start-writing-btn {
   appearance: none;
   border: none;
@@ -1433,6 +1440,11 @@ body {
   display: block;
   width: clamp(180px, 40vw, 320px);
   height: auto;
+}
+
+.start-writing-my-letters-btn {
+  justify-content: center;
+  min-width: 160px;
 }
 
 @keyframes soft-bounce {

--- a/frontend/src/app/global.css
+++ b/frontend/src/app/global.css
@@ -1421,30 +1421,70 @@ body {
 }
 
 .start-writing-btn {
-  appearance: none;
-  border: none;
-  background: transparent;
-  padding: 0;
-  cursor: pointer;
   animation: soft-bounce 2.6s ease-in-out infinite;
   will-change: transform;
   transform-origin: center;
-  line-height: 0; /* remove inline button baseline gap */
-  display: inline-block;
-}
-.start-writing-btn:hover {
-  transform: translateY(-1px) scale(1.02);
 }
 
-.start-writing-img {
-  display: block;
-  width: clamp(180px, 40vw, 320px);
-  height: auto;
+.start-writing-actions .cta-pill {
+  width: clamp(220px, 44vw, 320px);
 }
 
 .start-writing-my-letters-btn {
   justify-content: center;
-  min-width: 160px;
+}
+
+.cta-pill {
+  appearance: none;
+  border: none;
+  border-radius: 9999px;
+  padding: clamp(16px, 3vw, 20px) clamp(32px, 6vw, 56px);
+  font-size: clamp(1rem, 2.4vw, 1.3rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+  color: inherit;
+}
+
+.cta-pill:hover:not(:disabled) {
+  transform: translateY(-2px) scale(1.01);
+}
+
+.cta-pill:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.55);
+  outline-offset: 3px;
+}
+
+.cta-pill:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+  transform: none;
+}
+
+.cta-pill--primary {
+  background: linear-gradient(140deg, #00c6ff 0%, #0061ff 100%);
+  color: #ffffff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 18px 36px rgba(0, 97, 255, 0.35);
+}
+
+.cta-pill--secondary {
+  background: linear-gradient(140deg, #fde68a 0%, #f59e0b 100%);
+  color: #78350f;
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.35);
+  box-shadow: 0 16px 32px rgba(217, 119, 6, 0.25);
+}
+
+.writing-desk-my-letters-btn {
+  width: 100%;
+  min-height: 56px;
 }
 
 @keyframes soft-bounce {

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -2622,6 +2622,13 @@ ${letterDocumentBodyHtml}
                         ? 'Saved to my letters'
                         : 'Save to my letters'}
                   </button>
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    disabled={!(savedLetterResponseId !== null && savedLetterResponseId === letterResponseId)}
+                  >
+                    My Letters
+                  </button>
                   <button type="button" className="btn-primary" onClick={handleCopyLetter}>
                     {letterCopyState === 'copied' ? 'Copied!' : letterCopyState === 'error' ? 'Copy failed — try again' : 'Copy for email'}
                   </button>

--- a/frontend/src/app/writingDesk/WritingDeskClient.tsx
+++ b/frontend/src/app/writingDesk/WritingDeskClient.tsx
@@ -2624,7 +2624,7 @@ ${letterDocumentBodyHtml}
                   </button>
                   <button
                     type="button"
-                    className="btn-secondary"
+                    className="cta-pill cta-pill--secondary writing-desk-my-letters-btn"
                     disabled={!(savedLetterResponseId !== null && savedLetterResponseId === letterResponseId)}
                   >
                     My Letters

--- a/frontend/src/components/StartWritingButton.tsx
+++ b/frontend/src/components/StartWritingButton.tsx
@@ -73,19 +73,14 @@ export default function StartWritingButton() {
       <div className="start-writing-actions">
         <button
           type="button"
-          className="start-writing-btn"
+          className="start-writing-btn cta-pill cta-pill--primary"
           aria-label="Start writing"
           aria-busy={checking}
           onClick={handleClick}
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="/assets/start_writing.png"
-            alt="Start writing"
-            className="start-writing-img"
-          />
+          Start Writing
         </button>
-        <button type="button" className="btn-secondary start-writing-my-letters-btn">
+        <button type="button" className="start-writing-my-letters-btn cta-pill cta-pill--secondary">
           My Letters
         </button>
       </div>

--- a/frontend/src/components/StartWritingButton.tsx
+++ b/frontend/src/components/StartWritingButton.tsx
@@ -70,20 +70,25 @@ export default function StartWritingButton() {
 
   return (
     <div className="container start-writing-panel">
-      <button
-        type="button"
-        className="start-writing-btn"
-        aria-label="Start writing"
-        aria-busy={checking}
-        onClick={handleClick}
-      >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src="/assets/start_writing.png"
-          alt="Start writing"
-          className="start-writing-img"
-        />
-      </button>
+      <div className="start-writing-actions">
+        <button
+          type="button"
+          className="start-writing-btn"
+          aria-label="Start writing"
+          aria-busy={checking}
+          onClick={handleClick}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/assets/start_writing.png"
+            alt="Start writing"
+            className="start-writing-img"
+          />
+        </button>
+        <button type="button" className="btn-secondary start-writing-my-letters-btn">
+          My Letters
+        </button>
+      </div>
 
       {toast && <Toast>{toast}</Toast>}
     </div>


### PR DESCRIPTION
## Summary
- add a My Letters control to the writing desk actions and keep it disabled until a letter is saved
- place a My Letters button alongside the start writing call-to-action and adjust layout styles to support it

## Testing
- npx nx lint frontend *(fails: Cannot find configuration for task frontend:lint)*

------
https://chatgpt.com/codex/tasks/task_e_68f69bd20ce8832195aa5a7ebaeab6bb