### PR TITLE
Add My letters navigation link for authenticated users

### DIFF
--- a/frontend/src/components/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader.tsx
@@ -42,7 +42,12 @@ export default async function SiteHeader() {
         </div>
         <nav className="nav">
           <Link href="/how-it-works" className="hide-mobile">How it works</Link>
-          {isAuthed && <Link href="/dashboard">Dashboard</Link>}
+          {isAuthed && (
+            <>
+              <Link href="/dashboard">Dashboard</Link>
+              <Link href="/myLetters">My letters</Link>
+            </>
+          )}
 
           {!isAuthed ? (
             <a href="/api/auth/google?returnTo=/dashboard" className="google-btn" aria-label="Sign in with Google">


### PR DESCRIPTION
## Summary
- show an additional navigation link to the My letters page when a user is authenticated

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7f0c151808321b6b399647912986a