### PR TITLE
feat(frontend): add my letters browsing view

### DIFF
--- a/frontend/src/app/myLetters/MyLettersClient.tsx
+++ b/frontend/src/app/myLetters/MyLettersClient.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { listSavedLetters } from '../../features/my-letters/api/letters';
+import { SavedLetterResource } from '../../features/writing-desk/api/letter';
+import {
+  copyLetterToClipboard,
+  downloadLetterAsDocx,
+  downloadLetterAsPdf,
+  normaliseLetterHtml,
+} from '../../features/writing-desk/utils/letterPresentation';
+
+type CopyState = 'idle' | 'copied' | 'error';
+
+const DEFAULT_DATE_RANGE_DAYS = 30;
+
+function formatDateInput(date: Date): string {
+  const iso = date.toISOString();
+  return iso.slice(0, 10);
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function formatDateTimeDisplay(value: string | null | undefined): string {
+  if (!value) return '';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(parsed);
+}
+
+function sortLettersDescending(letters: SavedLetterResource[]): SavedLetterResource[] {
+  return [...letters].sort((a, b) => {
+    const aTime = new Date(a.createdAt ?? 0).getTime();
+    const bTime = new Date(b.createdAt ?? 0).getTime();
+    return bTime - aTime;
+  });
+}
+
+function formatToneLabel(tone: string | null | undefined): string | null {
+  if (!tone) return null;
+  return tone
+    .split('_')
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export default function MyLettersClient() {
+  const today = useMemo(() => new Date(), []);
+  const defaultEndDate = useMemo(() => formatDateInput(today), [today]);
+  const defaultStartDate = useMemo(
+    () => formatDateInput(addDays(today, -DEFAULT_DATE_RANGE_DAYS)),
+    [today],
+  );
+
+  const [startDate, setStartDate] = useState<string>(defaultStartDate);
+  const [endDate, setEndDate] = useState<string>(defaultEndDate);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+  const [isDownloadingPdf, setIsDownloadingPdf] = useState(false);
+  const [isDownloadingDocx, setIsDownloadingDocx] = useState(false);
+
+  const isRangeValid = useMemo(() => {
+    if (!startDate || !endDate) return true;
+    return startDate <= endDate;
+  }, [startDate, endDate]);
+
+  const queryKey = useMemo(() => ['myLetters', { startDate, endDate }], [startDate, endDate]);
+
+  const savedLettersQuery = useQuery({
+    queryKey,
+    queryFn: () => listSavedLetters({ startDate, endDate }),
+    enabled: isRangeValid,
+    keepPreviousData: true,
+  });
+
+  const letters = useMemo(() => {
+    const items = savedLettersQuery.data?.letters;
+    if (!Array.isArray(items)) {
+      return [] as SavedLetterResource[];
+    }
+    return sortLettersDescending(items);
+  }, [savedLettersQuery.data]);
+
+  const currentLetter = letters[currentIndex] ?? null;
+  const totalLetters = letters.length;
+  const todayIso = useMemo(() => formatDateInput(today), [today]);
+  const savedTimestamp = useMemo(() => {
+    if (!currentLetter) return '';
+    return formatDateTimeDisplay(currentLetter.updatedAt || currentLetter.createdAt);
+  }, [currentLetter]);
+  const toneLabel = useMemo(() => formatToneLabel(currentLetter?.metadata?.tone ?? null), [currentLetter]);
+
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [startDate, endDate]);
+
+  useEffect(() => {
+    if (currentIndex > 0 && currentIndex > totalLetters - 1) {
+      setCurrentIndex(totalLetters > 0 ? totalLetters - 1 : 0);
+    }
+  }, [currentIndex, totalLetters]);
+
+  useEffect(() => {
+    setCopyState('idle');
+    setIsDownloadingDocx(false);
+    setIsDownloadingPdf(false);
+  }, [currentIndex]);
+
+  const handleStartDateChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setStartDate(event.target.value);
+  }, []);
+
+  const handleEndDateChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setEndDate(event.target.value);
+  }, []);
+
+  const handleCopyLetter = useCallback(async () => {
+    if (!currentLetter?.letterHtml) {
+      setCopyState('error');
+      return;
+    }
+    try {
+      await copyLetterToClipboard(currentLetter.letterHtml);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+  }, [currentLetter]);
+
+  const handleDownloadPdf = useCallback(async () => {
+    if (!currentLetter) return;
+    if (isDownloadingPdf) return;
+    setIsDownloadingPdf(true);
+    try {
+      await downloadLetterAsPdf(normaliseLetterHtml(currentLetter.letterHtml), currentLetter.metadata);
+    } catch (error) {
+      console.error('Failed to prepare PDF download', error);
+    } finally {
+      setIsDownloadingPdf(false);
+    }
+  }, [currentLetter, isDownloadingPdf]);
+
+  const handleDownloadDocx = useCallback(async () => {
+    if (!currentLetter) return;
+    if (isDownloadingDocx) return;
+    setIsDownloadingDocx(true);
+    try {
+      await downloadLetterAsDocx(normaliseLetterHtml(currentLetter.letterHtml), currentLetter.metadata);
+    } catch (error) {
+      console.error('Failed to prepare DOCX download', error);
+    } finally {
+      setIsDownloadingDocx(false);
+    }
+  }, [currentLetter, isDownloadingDocx]);
+
+  const goToFirst = useCallback(() => {
+    setCurrentIndex(0);
+  }, []);
+
+  const goToPrevious = useCallback(() => {
+    setCurrentIndex((prev) => Math.max(prev - 1, 0));
+  }, []);
+
+  const goToNext = useCallback(() => {
+    setCurrentIndex((prev) => Math.min(prev + 1, Math.max(totalLetters - 1, 0)));
+  }, [totalLetters]);
+
+  const goToLast = useCallback(() => {
+    if (totalLetters === 0) {
+      setCurrentIndex(0);
+    } else {
+      setCurrentIndex(totalLetters - 1);
+    }
+  }, [totalLetters]);
+
+  const references = useMemo(() => {
+    if (!Array.isArray(currentLetter?.metadata?.references)) {
+      return [];
+    }
+    return currentLetter.metadata.references.filter(
+      (ref): ref is string => typeof ref === 'string' && ref.trim().length > 0,
+    );
+  }, [currentLetter]);
+
+  const copyLabel = useMemo(() => {
+    if (copyState === 'copied') return 'Copied!';
+    if (copyState === 'error') return 'Copy failed — try again';
+    return 'Copy for email';
+  }, [copyState]);
+
+  const isLoading = savedLettersQuery.isLoading || savedLettersQuery.isFetching;
+  const error = savedLettersQuery.error;
+  const errorMessage = useMemo(() => {
+    if (!error) return null;
+    return error instanceof Error ? error.message : 'We could not load your saved letters. Please try again.';
+  }, [error]);
+
+  const showEmptyState = !isLoading && totalLetters === 0 && isRangeValid && !errorMessage;
+
+  return (
+    <section className="card" style={{ marginTop: 16 }}>
+      <div className="container">
+        <header style={{ marginBottom: 16 }}>
+          <div className="section-header">
+            <div>
+              <h2 className="section-title">My letters</h2>
+              <p className="section-sub">Browse the letters you&apos;ve saved from the writing desk.</p>
+            </div>
+          </div>
+        </header>
+
+        <div
+          className="card"
+          style={{ padding: 16, marginBottom: 16, display: 'grid', gap: 12 }}
+          aria-label="Filter saved letters by date range"
+        >
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+            <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.9rem', minWidth: 180 }}>
+              <span style={{ marginBottom: 4, fontWeight: 600 }}>From</span>
+              <input
+                type="date"
+                value={startDate}
+                max={endDate || todayIso}
+                onChange={handleStartDateChange}
+                className="input"
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.9rem', minWidth: 180 }}>
+              <span style={{ marginBottom: 4, fontWeight: 600 }}>To</span>
+              <input
+                type="date"
+                value={endDate}
+                min={startDate || undefined}
+                max={todayIso}
+                onChange={handleEndDateChange}
+                className="input"
+              />
+            </label>
+          </div>
+          {!isRangeValid && (
+            <p role="alert" aria-live="polite" style={{ margin: 0, color: '#b91c1c' }}>
+              The start date must be on or before the end date.
+            </p>
+          )}
+        </div>
+
+        {isLoading && (
+          <p style={{ marginTop: 16 }} role="status" aria-live="polite">
+            Loading your saved letters…
+          </p>
+        )}
+
+        {errorMessage && (
+          <p role="alert" aria-live="polite" style={{ marginTop: 16, color: '#b91c1c' }}>
+            {errorMessage}
+          </p>
+        )}
+
+        {showEmptyState && (
+          <div className="card" style={{ padding: 16 }}>
+            <p style={{ margin: 0 }}>You don&apos;t have any saved letters for this date range yet.</p>
+          </div>
+        )}
+
+        {isRangeValid && currentLetter && (
+          <div className="card" style={{ padding: 16, display: 'grid', gap: 16 }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <h3 style={{ margin: 0, fontSize: '1.1rem' }}>{currentLetter.metadata?.mpName || 'MP letter'}</h3>
+                <p style={{ margin: '4px 0 0 0', color: '#6b7280' }}>
+                  Saved {savedTimestamp || '—'}
+                  {toneLabel ? ` · Tone: ${toneLabel}` : ''}
+                  {currentLetter.metadata?.date ? ` · Letter date: ${currentLetter.metadata.date}` : ''}
+                </p>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={goToFirst}
+                  disabled={totalLetters <= 1 || currentIndex === 0}
+                  aria-label="Go to first letter"
+                >
+                  «
+                </button>
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={goToPrevious}
+                  disabled={totalLetters <= 1 || currentIndex === 0}
+                  aria-label="Go to previous letter"
+                >
+                  ‹
+                </button>
+                <span style={{ fontSize: '0.9rem' }}>
+                  Letter {currentIndex + 1} of {totalLetters}
+                </span>
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={goToNext}
+                  disabled={totalLetters <= 1 || currentIndex >= totalLetters - 1}
+                  aria-label="Go to next letter"
+                >
+                  ›
+                </button>
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={goToLast}
+                  disabled={totalLetters <= 1 || currentIndex >= totalLetters - 1}
+                  aria-label="Go to last letter"
+                >
+                  »
+                </button>
+              </div>
+            </div>
+
+            <div
+              className="letter-preview"
+              dangerouslySetInnerHTML={{ __html: normaliseLetterHtml(currentLetter.letterHtml) }}
+            />
+
+            <div
+              className="actions"
+              style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 12 }}
+            >
+              <button type="button" className="btn-primary" onClick={handleCopyLetter}>
+                {copyLabel}
+              </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={handleDownloadPdf}
+                disabled={isDownloadingPdf}
+                aria-busy={isDownloadingPdf}
+              >
+                {isDownloadingPdf ? 'Preparing PDF…' : 'Download PDF'}
+              </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={handleDownloadDocx}
+                disabled={isDownloadingDocx}
+                aria-busy={isDownloadingDocx}
+              >
+                {isDownloadingDocx ? 'Preparing DOCX…' : 'Download DOCX'}
+              </button>
+            </div>
+
+            {references.length > 0 && (
+              <div>
+                <h4 style={{ margin: '8px 0', fontSize: '0.95rem' }}>References included</h4>
+                <ul style={{ margin: 0, paddingLeft: 18 }}>
+                  {references.map((ref) => (
+                    <li key={ref}>{ref}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/myLetters/page.tsx
+++ b/frontend/src/app/myLetters/page.tsx
@@ -1,0 +1,5 @@
+import MyLettersClient from './MyLettersClient';
+
+export default function MyLettersPage() {
+  return <MyLettersClient />;
+}

--- a/frontend/src/features/my-letters/api/letters.ts
+++ b/frontend/src/features/my-letters/api/letters.ts
@@ -1,0 +1,49 @@
+import { SavedLetterResource } from '../../writing-desk/api/letter';
+
+export interface ListSavedLettersParams {
+  startDate?: string | null;
+  endDate?: string | null;
+}
+
+export interface ListSavedLettersResponse {
+  letters: SavedLetterResource[];
+  totalCount?: number;
+}
+
+function buildQueryString(params: ListSavedLettersParams): string {
+  const searchParams = new URLSearchParams();
+  if (params.startDate) {
+    searchParams.set('startDate', params.startDate);
+  }
+  if (params.endDate) {
+    searchParams.set('endDate', params.endDate);
+  }
+  const query = searchParams.toString();
+  return query.length > 0 ? `?${query}` : '';
+}
+
+export async function listSavedLetters(params: ListSavedLettersParams): Promise<ListSavedLettersResponse> {
+  const res = await fetch(`/api/user/saved-letters${buildQueryString(params)}`, {
+    method: 'GET',
+    credentials: 'include',
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Request failed (${res.status})`);
+  }
+
+  const data = await res.json().catch(() => null);
+
+  if (Array.isArray(data)) {
+    return { letters: data };
+  }
+
+  if (data && Array.isArray(data.letters)) {
+    const totalCount = typeof data.totalCount === 'number' ? data.totalCount : undefined;
+    return { letters: data.letters, totalCount };
+  }
+
+  throw new Error('We could not load your saved letters. Please try again.');
+}

--- a/frontend/src/features/writing-desk/utils/letterPresentation.ts
+++ b/frontend/src/features/writing-desk/utils/letterPresentation.ts
@@ -1,0 +1,213 @@
+import { letterHtmlToPlainText } from './composeLetterHtml';
+
+export const LETTER_DOCUMENT_CSS = `
+  @page {
+    margin: 15mm;
+  }
+
+  body {
+    font-family: "Times New Roman", serif;
+    font-size: 12pt;
+    line-height: 1.5;
+    color: #111827;
+    margin: 0;
+    background: #ffffff;
+  }
+
+  .letter-document {
+    box-sizing: border-box;
+    max-width: 180mm;
+    margin: 0 auto;
+    padding: 15mm;
+  }
+
+  .letter-document p {
+    margin: 0 0 12pt 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .letter-document ul,
+  .letter-document ol {
+    margin: 0 0 12pt 20pt;
+    padding: 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .letter-document li {
+    margin: 0 0 6pt 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .letter-document a {
+    color: #1d4ed8;
+    text-decoration: underline;
+    word-break: break-word;
+  }
+`;
+
+export const LETTER_HTML_FALLBACK = '<p>No content available.</p>';
+
+export interface LetterDownloadMetadata {
+  mpName?: string | null;
+  date?: string | null;
+}
+
+export function normaliseLetterHtml(letterHtml?: string | null): string {
+  if (typeof letterHtml !== 'string') {
+    return LETTER_HTML_FALLBACK;
+  }
+  const trimmed = letterHtml.trim();
+  return trimmed.length > 0 ? trimmed : LETTER_HTML_FALLBACK;
+}
+
+export function createLetterDocumentBodyHtml(letterHtml?: string | null): string {
+  return `<div class="letter-document">${normaliseLetterHtml(letterHtml)}</div>`;
+}
+
+export function createLetterDocxHtml(letterHtml?: string | null): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>
+${LETTER_DOCUMENT_CSS}
+</style>
+</head>
+<body>
+${createLetterDocumentBodyHtml(letterHtml)}
+</body>
+</html>`;
+}
+
+export function resolveLetterDownloadFilename(
+  metadata: LetterDownloadMetadata | null | undefined,
+  extension: 'pdf' | 'docx',
+): string {
+  const mpName = typeof metadata?.mpName === 'string' ? metadata.mpName.trim() : '';
+  const dateValue =
+    typeof metadata?.date === 'string' && metadata.date.trim().length > 0
+      ? metadata.date.trim()
+      : new Date().toISOString().slice(0, 10);
+  const baseParts = [mpName, dateValue].filter((part) => part.length > 0);
+  const baseRaw = baseParts.join('-') || 'mp-letter';
+  const slug = baseRaw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const safeBase = slug.length > 0 ? slug : 'mp-letter';
+  return `${safeBase}.${extension}`;
+}
+
+export function triggerLetterBlobDownload(blob: Blob, filename: string) {
+  if (typeof window === 'undefined') return;
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 0);
+}
+
+export async function copyLetterToClipboard(letterHtml: string): Promise<void> {
+  const safeHtml = normaliseLetterHtml(letterHtml);
+
+  try {
+    if (
+      typeof window !== 'undefined' &&
+      'ClipboardItem' in window &&
+      navigator.clipboard &&
+      'write' in navigator.clipboard
+    ) {
+      const htmlBlob = new Blob([safeHtml], { type: 'text/html' });
+      const plainText = letterHtmlToPlainText(safeHtml);
+      const textBlob = new Blob([plainText], { type: 'text/plain' });
+      const item = new (window as any).ClipboardItem({ 'text/html': htmlBlob, 'text/plain': textBlob });
+      await (navigator.clipboard as any).write([item]);
+      return;
+    }
+
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(letterHtmlToPlainText(safeHtml));
+      return;
+    }
+
+    throw new Error('Clipboard API not available');
+  } catch (initialError) {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(letterHtmlToPlainText(safeHtml));
+        return;
+      }
+    } catch {
+      // Ignore nested failure and rethrow original error below.
+    }
+
+    if (initialError instanceof Error) {
+      throw initialError;
+    }
+    throw new Error('Unable to copy letter content');
+  }
+}
+
+export async function downloadLetterAsDocx(letterHtml: string, metadata: LetterDownloadMetadata | null | undefined) {
+  if (typeof window === 'undefined') return;
+  const htmlDocxModule = await import('html-docx-js/dist/html-docx.js');
+  const htmlDocx = (htmlDocxModule.default ?? htmlDocxModule) as { asBlob: (input: string) => Blob };
+  const blob = htmlDocx.asBlob(createLetterDocxHtml(letterHtml));
+  triggerLetterBlobDownload(blob, resolveLetterDownloadFilename(metadata, 'docx'));
+}
+
+export async function downloadLetterAsPdf(
+  letterHtml: string,
+  metadata: LetterDownloadMetadata | null | undefined,
+): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  const container = document.createElement('div');
+  let appended = false;
+
+  try {
+    container.style.position = 'fixed';
+    container.style.left = '-9999px';
+    container.style.top = '0';
+    container.style.width = '210mm';
+    container.style.padding = '0';
+    container.style.margin = '0';
+    container.style.background = '#ffffff';
+    container.style.zIndex = '-1';
+    container.setAttribute('aria-hidden', 'true');
+    container.innerHTML = `<style>${LETTER_DOCUMENT_CSS}</style>${createLetterDocumentBodyHtml(letterHtml)}`;
+    document.body.appendChild(container);
+    appended = true;
+
+    const target = container.querySelector('.letter-document') as HTMLElement | null;
+    if (!target) {
+      throw new Error('Unable to locate letter content for export');
+    }
+
+    const html2pdfModule = (await import('html2pdf.js')) as any;
+    const html2pdf = html2pdfModule.default ?? html2pdfModule;
+
+    await html2pdf()
+      .set({
+        margin: [15, 15, 15, 15],
+        filename: resolveLetterDownloadFilename(metadata, 'pdf'),
+        pagebreak: { mode: ['css', 'legacy'] },
+        html2canvas: { scale: 2, useCORS: true, logging: false },
+        jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+      })
+      .from(target)
+      .save();
+  } finally {
+    if (appended && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated /myLetters route with a client component for filtering and paging through saved letters
- create a shared letter presentation utility to reuse copy and export logic across writing desk surfaces
- switch the writing desk client to the shared helpers so downloads and clipboard features behave consistently

## Testing
- npx nx lint frontend *(fails: Cannot find configuration for task frontend:lint)*

------
https://chatgpt.com/codex/tasks/task_e_68f81ced222c8321826028c4b2773644