### PR TITLE
feat: add paginated saved letters listing endpoint

### DIFF
--- a/backend-api/src/user-saved-letters/dto/list-saved-letters.dto.ts
+++ b/backend-api/src/user-saved-letters/dto/list-saved-letters.dto.ts
@@ -1,0 +1,24 @@
+import { Type } from 'class-transformer';
+import { IsDateString, IsInt, IsOptional, Min } from 'class-validator';
+
+export class ListSavedLettersDto {
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  pageSize?: number;
+}

--- a/backend-api/src/user-saved-letters/user-saved-letters.controller.ts
+++ b/backend-api/src/user-saved-letters/user-saved-letters.controller.ts
@@ -1,13 +1,29 @@
-import { BadRequestException, Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { SaveLetterDto } from './dto/save-letter.dto';
 import { UserSavedLettersService } from './user-saved-letters.service';
 import { LookupSavedLettersDto } from './dto/lookup-saved-letter.dto';
+import { ListSavedLettersDto } from './dto/list-saved-letters.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('user/saved-letters')
 export class UserSavedLettersController {
   constructor(private readonly savedLetters: UserSavedLettersService) {}
+
+  @Get()
+  async listSavedLetters(@Req() req: any, @Query() query: ListSavedLettersDto) {
+    const userId = req?.user?.id ?? req?.user?._id ?? null;
+    if (!userId) {
+      throw new BadRequestException('User account required');
+    }
+
+    return this.savedLetters.findByDateRange(userId, {
+      startDate: query.startDate ?? undefined,
+      endDate: query.endDate ?? undefined,
+      page: query.page,
+      pageSize: query.pageSize,
+    });
+  }
 
   @Post()
   async saveLetter(@Req() req: any, @Body() body: SaveLetterDto) {

--- a/backend-api/src/user-saved-letters/user-saved-letters.module.ts
+++ b/backend-api/src/user-saved-letters/user-saved-letters.module.ts
@@ -11,3 +11,10 @@ import { UserSavedLetter, UserSavedLetterSchema } from './schemas/user-saved-let
   exports: [UserSavedLettersService],
 })
 export class UserSavedLettersModule {}
+
+export { ListSavedLettersDto } from './dto/list-saved-letters.dto';
+export type {
+  PaginatedUserSavedLettersResult,
+  SavedLetterMetadata,
+  UserSavedLetterResource,
+} from './user-saved-letters.service';

--- a/frontend/src/features/my-letters/api/letters.ts
+++ b/frontend/src/features/my-letters/api/letters.ts
@@ -1,13 +1,21 @@
 import { SavedLetterResource } from '../../writing-desk/api/letter';
 
+/**
+ * Fetch saved letters for the authenticated user via GET /api/user/saved-letters.
+ * Supports optional date range filtering and pagination so the UI can navigate between pages.
+ */
 export interface ListSavedLettersParams {
   startDate?: string | null;
   endDate?: string | null;
+  page?: number;
+  pageSize?: number;
 }
 
 export interface ListSavedLettersResponse {
   letters: SavedLetterResource[];
   totalCount?: number;
+  page?: number;
+  pageSize?: number;
 }
 
 function buildQueryString(params: ListSavedLettersParams): string {
@@ -17,6 +25,12 @@ function buildQueryString(params: ListSavedLettersParams): string {
   }
   if (params.endDate) {
     searchParams.set('endDate', params.endDate);
+  }
+  if (typeof params.page === 'number') {
+    searchParams.set('page', String(params.page));
+  }
+  if (typeof params.pageSize === 'number') {
+    searchParams.set('pageSize', String(params.pageSize));
   }
   const query = searchParams.toString();
   return query.length > 0 ? `?${query}` : '';
@@ -42,7 +56,9 @@ export async function listSavedLetters(params: ListSavedLettersParams): Promise<
 
   if (data && Array.isArray(data.letters)) {
     const totalCount = typeof data.totalCount === 'number' ? data.totalCount : undefined;
-    return { letters: data.letters, totalCount };
+    const page = typeof data.page === 'number' ? data.page : undefined;
+    const pageSize = typeof data.pageSize === 'number' ? data.pageSize : undefined;
+    return { letters: data.letters, totalCount, page, pageSize };
   }
 
   throw new Error('We could not load your saved letters. Please try again.');


### PR DESCRIPTION
## Summary
- add a query DTO for saved letter list filters and pagination parameters
- extend the saved letters service and controller with a guarded GET endpoint that returns paginated results
- document the route in the frontend API helper so the client can request pages and read pagination metadata

## Testing
- npx nx lint backend-api *(fails: container session crashed before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68f821011e4883218e529b9d569639f3