### PR TITLE
feat: add saved letters listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Auth & API (Backend)
 - Current user: `GET /api/auth/me` (Authorization: `Bearer <token>`)
 - Purchases: `GET /api/purchases`, `POST /api/purchases`, `GET /api/purchases/:id`
 - OpenAI: `POST /api/ai/generate` (Authorization required)
+- Saved letters: `GET /api/user/saved-letters` (Authorization required) — optional query
+  params `from`, `to`, `page`, `pageSize`; responds with `{ data, total, page, pageSize }`
+  so the UI can paginate saved correspondence.
 
 Persisting a User's MP
 - Model: separate collection `user_mps` keyed by `user` (ObjectId). See `backend-api/src/user-mp/schemas/user-mp.schema.ts`.

--- a/backend-api/src/user-saved-letters/dto/list-saved-letters.dto.ts
+++ b/backend-api/src/user-saved-letters/dto/list-saved-letters.dto.ts
@@ -1,0 +1,27 @@
+import { Type } from 'class-transformer';
+import { IsDate, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class ListSavedLettersDto {
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  from?: Date;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  to?: Date;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize: number = 20;
+}

--- a/backend-api/src/user-saved-letters/user-saved-letters.controller.ts
+++ b/backend-api/src/user-saved-letters/user-saved-letters.controller.ts
@@ -1,8 +1,9 @@
-import { BadRequestException, Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { SaveLetterDto } from './dto/save-letter.dto';
 import { UserSavedLettersService } from './user-saved-letters.service';
 import { LookupSavedLettersDto } from './dto/lookup-saved-letter.dto';
+import { ListSavedLettersDto } from './dto/list-saved-letters.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('user/saved-letters')
@@ -29,5 +30,19 @@ export class UserSavedLettersController {
       userId,
       responseIds.filter((id): id is string => typeof id === 'string' && id.trim().length > 0),
     );
+  }
+
+  @Get()
+  async listSavedLetters(@Req() req: any, @Query() query: ListSavedLettersDto) {
+    const userId = req?.user?.id ?? req?.user?._id ?? null;
+    if (!userId) {
+      throw new BadRequestException('User account required');
+    }
+
+    if (query.from && query.to && query.from.getTime() > query.to.getTime()) {
+      throw new BadRequestException('`from` date must be before or equal to `to` date');
+    }
+
+    return this.savedLetters.findByDateRange(userId, query);
   }
 }

--- a/backend-api/src/user-saved-letters/user-saved-letters.service.spec.ts
+++ b/backend-api/src/user-saved-letters/user-saved-letters.service.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { UserSavedLettersService } from './user-saved-letters.service';
+import { EncryptionService } from '../crypto/encryption.service';
+import { UserSavedLetter } from './schemas/user-saved-letter.schema';
+import { ListSavedLettersDto } from './dto/list-saved-letters.dto';
+
+const createFindChain = () => {
+  const chain: any = {
+    sort: jest.fn(),
+    skip: jest.fn(),
+    limit: jest.fn(),
+    lean: jest.fn(),
+    exec: jest.fn(),
+  };
+  chain.sort.mockReturnValue(chain);
+  chain.skip.mockReturnValue(chain);
+  chain.limit.mockReturnValue(chain);
+  chain.lean.mockReturnValue(chain);
+  return chain;
+};
+
+describe('UserSavedLettersService', () => {
+  let service: UserSavedLettersService;
+  const model = {
+    find: jest.fn(),
+    countDocuments: jest.fn(),
+  };
+  const encryption = {
+    encryptObject: jest.fn(),
+    decryptObject: jest.fn((value) => value),
+  } as unknown as EncryptionService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserSavedLettersService,
+        {
+          provide: getModelToken(UserSavedLetter.name),
+          useValue: model,
+        },
+        {
+          provide: EncryptionService,
+          useValue: encryption,
+        },
+      ],
+    }).compile();
+
+    service = module.get(UserSavedLettersService);
+  });
+
+  describe('findByDateRange', () => {
+    it('filters by date range and applies pagination', async () => {
+      const from = new Date('2024-01-01T00:00:00.000Z');
+      const to = new Date('2024-02-01T00:00:00.000Z');
+      const docs = [
+        {
+          _id: 'abc123',
+          user: 'user-1',
+          responseId: 'resp-1',
+          letterHtmlCiphertext: '<p>Hello</p>',
+          metadataCiphertext: {
+            mpName: 'MP Name',
+            letterContent: 'Letter body',
+            references: ['ref1'],
+            tone: 'friendly',
+            rawJson: '{}',
+          },
+          referencesCiphertext: ['ref1'],
+          rawJsonCiphertext: '{}',
+          createdAt: new Date('2024-01-15T12:00:00.000Z'),
+          updatedAt: new Date('2024-01-16T12:00:00.000Z'),
+        },
+      ];
+      const findChain = createFindChain();
+      findChain.exec.mockResolvedValue(docs);
+      const countExec = jest.fn().mockResolvedValue(1);
+
+      (model.find as jest.Mock).mockReturnValue(findChain);
+      (model.countDocuments as jest.Mock).mockReturnValue({ exec: countExec });
+
+      const options = Object.assign(new ListSavedLettersDto(), {
+        from,
+        to,
+        page: 2,
+        pageSize: 5,
+      });
+
+      const result = await service.findByDateRange('user-1', options);
+
+      expect(model.find).toHaveBeenCalledWith({
+        user: 'user-1',
+        createdAt: { $gte: from, $lte: to },
+      });
+      expect(findChain.sort).toHaveBeenCalledWith({ createdAt: -1 });
+      expect(findChain.skip).toHaveBeenCalledWith(5);
+      expect(findChain.limit).toHaveBeenCalledWith(5);
+      expect(model.countDocuments).toHaveBeenCalledWith({
+        user: 'user-1',
+        createdAt: { $gte: from, $lte: to },
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(2);
+      expect(result.pageSize).toBe(5);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: 'abc123',
+        responseId: 'resp-1',
+        letterHtml: '<p>Hello</p>',
+        metadata: expect.objectContaining({
+          mpName: 'MP Name',
+          tone: 'friendly',
+        }),
+      });
+    });
+
+    it('returns empty results when nothing matches', async () => {
+      const findChain = createFindChain();
+      findChain.exec.mockResolvedValue([]);
+      const countExec = jest.fn().mockResolvedValue(0);
+
+      (model.find as jest.Mock).mockReturnValue(findChain);
+      (model.countDocuments as jest.Mock).mockReturnValue({ exec: countExec });
+
+      const result = await service.findByDateRange('user-2', Object.assign(new ListSavedLettersDto(), {}));
+
+      expect(result.total).toBe(0);
+      expect(result.data).toEqual([]);
+    });
+
+    it('uses default pagination values when not provided', async () => {
+      const docs = [];
+      const findChain = createFindChain();
+      findChain.exec.mockResolvedValue(docs);
+      const countExec = jest.fn().mockResolvedValue(0);
+
+      (model.find as jest.Mock).mockReturnValue(findChain);
+      (model.countDocuments as jest.Mock).mockReturnValue({ exec: countExec });
+
+      await service.findByDateRange('user-3', {} as ListSavedLettersDto);
+
+      expect(findChain.skip).toHaveBeenCalledWith(0);
+      expect(findChain.limit).toHaveBeenCalledWith(20);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a DTO to validate saved-letter list query parameters with defaults
- expose a GET /user/saved-letters endpoint that delegates to a paginated service query
- implement the date-range finder with pagination support and cover it with unit tests alongside new API docs

## Testing
- npx jest --config backend-api/jest.config.js user-saved-letters.service.spec.ts *(fails: Module @swc/jest in the transform option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f82a3d39d48321a5d5b0170fe57a55