### PR TITLE
Refine My Letters viewer to show one letter at a time

### DIFF
--- a/frontend/src/app/myLetters/MyLettersClient.tsx
+++ b/frontend/src/app/myLetters/MyLettersClient.tsx
@@ -148,7 +148,9 @@ export default function MyLettersClient() {
 
   const arrowButtonStyle: CSSProperties = {
     backgroundColor: '#eff6ff',
-    border: '1px solid #bfdbfe',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: '#bfdbfe',
     borderRadius: 9999,
     color: '#1d4ed8',
     cursor: 'pointer',

--- a/frontend/src/app/myLetters/MyLettersClient.tsx
+++ b/frontend/src/app/myLetters/MyLettersClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { LetterViewer } from '../../features/writing-desk/components/LetterViewer';
 import {
   useMyLettersQuery,
@@ -60,6 +60,8 @@ export default function MyLettersClient() {
   const [fromDate, setFromDate] = useState<string>('');
   const [toDate, setToDate] = useState<string>('');
   const [page, setPage] = useState<number>(1);
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const [pendingPageDirection, setPendingPageDirection] = useState<'next' | 'prev' | null>(null);
 
   const queryParams = useMemo(
     () => ({
@@ -78,7 +80,9 @@ export default function MyLettersClient() {
       return;
     }
     if (page > meta.totalPages) {
-      setPage(meta.totalPages);
+      setPage(Math.max(1, meta.totalPages));
+      setSelectedIndex(0);
+      setPendingPageDirection(null);
     }
   }, [meta, page]);
 
@@ -86,10 +90,112 @@ export default function MyLettersClient() {
   const hasLetters = letters.length > 0;
   const showEmpty = !isLoading && !isFetching && !hasLetters && !error;
 
-  const canGoFirst = meta.page > 1;
-  const canGoPrev = meta.hasPrevious && meta.page > 1;
-  const canGoNext = meta.hasNext && meta.page < meta.totalPages;
-  const canGoLast = meta.totalPages > 0 && meta.page < meta.totalPages;
+  useEffect(() => {
+    if (!hasLetters) {
+      if (selectedIndex !== 0) {
+        setSelectedIndex(0);
+      }
+      if (pendingPageDirection !== null) {
+        setPendingPageDirection(null);
+      }
+      return;
+    }
+
+    if (pendingPageDirection === 'next') {
+      if (selectedIndex !== 0) {
+        setSelectedIndex(0);
+      }
+      setPendingPageDirection(null);
+      return;
+    }
+
+    if (pendingPageDirection === 'prev') {
+      const lastIndex = Math.max(letters.length - 1, 0);
+      if (selectedIndex !== lastIndex) {
+        setSelectedIndex(lastIndex);
+      }
+      setPendingPageDirection(null);
+      return;
+    }
+
+    if (selectedIndex >= letters.length) {
+      setSelectedIndex(Math.max(letters.length - 1, 0));
+    }
+  }, [hasLetters, letters.length, pendingPageDirection, selectedIndex]);
+
+  const selectedLetter = letters[selectedIndex] ?? null;
+  const selectedMpName = selectedLetter ? resolveMpName(selectedLetter) : null;
+  const selectedToneLabel = selectedLetter ? resolveToneLabel(selectedLetter) : null;
+  const selectedDisplayDate = selectedLetter ? resolveDisplayDate(selectedLetter) : null;
+  const currentPage = Math.max(1, meta.page);
+
+  const totalLetters = useMemo(() => {
+    if (meta.totalItems > 0) {
+      return meta.totalItems;
+    }
+    if (meta.totalPages > 1) {
+      return meta.totalPages * meta.pageSize;
+    }
+    return letters.length;
+  }, [letters.length, meta.pageSize, meta.totalItems, meta.totalPages]);
+
+  const displayIndex = hasLetters ? (currentPage - 1) * meta.pageSize + selectedIndex + 1 : 0;
+
+  const canGoPrevPage = meta.hasPrevious && currentPage > 1;
+  const canGoNextPage = meta.hasNext && currentPage < meta.totalPages;
+  const canGoPrevLetter = hasLetters && (selectedIndex > 0 || canGoPrevPage);
+  const canGoNextLetter = hasLetters && (selectedIndex < letters.length - 1 || canGoNextPage);
+
+  const arrowButtonStyle: CSSProperties = {
+    backgroundColor: '#eff6ff',
+    border: '1px solid #bfdbfe',
+    borderRadius: 9999,
+    color: '#1d4ed8',
+    cursor: 'pointer',
+    fontSize: '1.5rem',
+    fontWeight: 600,
+    height: 56,
+    width: 56,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: 'background-color 0.2s ease, transform 0.2s ease',
+  };
+
+  const disabledArrowStyle: CSSProperties = {
+    backgroundColor: '#e5e7eb',
+    borderColor: '#d1d5db',
+    color: '#9ca3af',
+    cursor: 'not-allowed',
+  };
+
+  const handlePreviousLetter = () => {
+    if (!canGoPrevLetter) {
+      return;
+    }
+    if (selectedIndex > 0) {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+      return;
+    }
+    if (canGoPrevPage) {
+      setPendingPageDirection('prev');
+      setPage((prev) => Math.max(1, prev - 1));
+    }
+  };
+
+  const handleNextLetter = () => {
+    if (!canGoNextLetter) {
+      return;
+    }
+    if (selectedIndex < letters.length - 1) {
+      setSelectedIndex((prev) => Math.min(letters.length - 1, prev + 1));
+      return;
+    }
+    if (canGoNextPage) {
+      setPendingPageDirection('next');
+      setPage((prev) => prev + 1);
+    }
+  };
 
   return (
     <main className="hero-section">
@@ -120,10 +226,12 @@ export default function MyLettersClient() {
                   <input
                     type="date"
                     value={fromDate}
-                    onChange={(event) => {
-                      setFromDate(event.target.value);
-                      setPage(1);
-                    }}
+                  onChange={(event) => {
+                    setFromDate(event.target.value);
+                    setPage(1);
+                    setSelectedIndex(0);
+                    setPendingPageDirection(null);
+                  }}
                     aria-label="Filter letters from date"
                   />
                 </label>
@@ -132,10 +240,12 @@ export default function MyLettersClient() {
                   <input
                     type="date"
                     value={toDate}
-                    onChange={(event) => {
-                      setToDate(event.target.value);
-                      setPage(1);
-                    }}
+                  onChange={(event) => {
+                    setToDate(event.target.value);
+                    setPage(1);
+                    setSelectedIndex(0);
+                    setPendingPageDirection(null);
+                  }}
                     aria-label="Filter letters to date"
                   />
                 </label>
@@ -146,6 +256,8 @@ export default function MyLettersClient() {
                     setFromDate('');
                     setToDate('');
                     setPage(1);
+                    setSelectedIndex(0);
+                    setPendingPageDirection(null);
                     void refetch();
                   }}
                   style={{ height: 40 }}
@@ -155,53 +267,52 @@ export default function MyLettersClient() {
               </div>
             </section>
 
-            <nav aria-label="Saved letters pagination" style={{ marginBottom: 24 }}>
-              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage(1)}
-                  disabled={!canGoFirst}
-                  aria-disabled={!canGoFirst}
-                  aria-label="Go to first page"
+            {hasLetters && (
+              <nav aria-label="Browse saved letters" style={{ marginBottom: 24 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 24,
+                    justifyContent: 'center',
+                    flexWrap: 'wrap',
+                  }}
                 >
-                  {'<<'}
-                </button>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-                  disabled={!canGoPrev}
-                  aria-disabled={!canGoPrev}
-                  aria-label="Go to previous page"
-                >
-                  {'<'}
-                </button>
-                <span aria-live="polite" style={{ fontWeight: 600 }}>
-                  Page {meta.page} of {Math.max(1, meta.totalPages)}
-                </span>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage((prev) => prev + 1)}
-                  disabled={!canGoNext}
-                  aria-disabled={!canGoNext}
-                  aria-label="Go to next page"
-                >
-                  {'>'}
-                </button>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage(meta.totalPages || 1)}
-                  disabled={!canGoLast}
-                  aria-disabled={!canGoLast}
-                  aria-label="Go to last page"
-                >
-                  {'>>'}
-                </button>
-              </div>
-            </nav>
+                  <button
+                    type="button"
+                    onClick={handlePreviousLetter}
+                    disabled={!canGoPrevLetter}
+                    aria-disabled={!canGoPrevLetter}
+                    aria-label="View previous letter"
+                    style={{
+                      ...arrowButtonStyle,
+                      ...(canGoPrevLetter ? {} : disabledArrowStyle),
+                    }}
+                  >
+                    <span aria-hidden="true">‹</span>
+                  </button>
+                  <div style={{ textAlign: 'center', minWidth: 180 }}>
+                    <div style={{ fontWeight: 600, fontSize: '1.1rem' }}>
+                      Letter {displayIndex} of {Math.max(displayIndex, totalLetters)}
+                    </div>
+                    <div style={{ color: '#6b7280' }}>Page {currentPage} of {Math.max(1, meta.totalPages)}</div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleNextLetter}
+                    disabled={!canGoNextLetter}
+                    aria-disabled={!canGoNextLetter}
+                    aria-label="View next letter"
+                    style={{
+                      ...arrowButtonStyle,
+                      ...(canGoNextLetter ? {} : disabledArrowStyle),
+                    }}
+                  >
+                    <span aria-hidden="true">›</span>
+                  </button>
+                </div>
+              </nav>
+            )}
 
             {isFetching && !isLoading && (
               <div role="status" aria-live="polite" style={{ marginBottom: 24 }}>
@@ -227,84 +338,71 @@ export default function MyLettersClient() {
               </p>
             )}
 
-            <div style={{ display: 'grid', gap: 24 }}>
-              {letters.map((letter) => {
-                const mpName = resolveMpName(letter);
-                const displayDate = resolveDisplayDate(letter);
-                const toneLabel = resolveToneLabel(letter);
+            {selectedLetter && (
+              <article className="card" style={{ padding: 24 }}>
+                <header style={{ marginBottom: 16 }}>
+                  <h3 style={{ fontSize: '1.25rem', marginBottom: 4 }}>
+                    {selectedMpName ? `Letter to ${selectedMpName}` : 'Drafted letter'}
+                  </h3>
+                  <p style={{ margin: 0, color: '#6b7280' }}>
+                    Tone: {selectedToneLabel} · Saved on {selectedDisplayDate}
+                  </p>
+                  {selectedLetter.responseId && (
+                    <p style={{ margin: '4px 0 0', color: '#9ca3af', fontSize: '0.9rem' }}>
+                      Reference ID: {selectedLetter.responseId}
+                    </p>
+                  )}
+                </header>
+                <LetterViewer letterHtml={selectedLetter.letterHtml} metadata={selectedLetter.metadata} />
+              </article>
+            )}
 
-                return (
-                  <article
-                    key={letter.id}
-                    className="card"
-                    style={{ padding: 24 }}
+            {hasLetters && (
+              <nav aria-label="Browse saved letters" style={{ marginTop: 32 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 24,
+                    justifyContent: 'center',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={handlePreviousLetter}
+                    disabled={!canGoPrevLetter}
+                    aria-disabled={!canGoPrevLetter}
+                    aria-label="View previous letter"
+                    style={{
+                      ...arrowButtonStyle,
+                      ...(canGoPrevLetter ? {} : disabledArrowStyle),
+                    }}
                   >
-                    <header style={{ marginBottom: 16 }}>
-                      <h3 style={{ fontSize: '1.25rem', marginBottom: 4 }}>
-                        {mpName ? `Letter to ${mpName}` : 'Drafted letter'}
-                      </h3>
-                      <p style={{ margin: 0, color: '#6b7280' }}>
-                        Tone: {toneLabel} · Saved on {displayDate}
-                      </p>
-                      {letter.responseId && (
-                        <p style={{ margin: '4px 0 0', color: '#9ca3af', fontSize: '0.9rem' }}>
-                          Reference ID: {letter.responseId}
-                        </p>
-                      )}
-                    </header>
-                    <LetterViewer letterHtml={letter.letterHtml} metadata={letter.metadata} />
-                  </article>
-                );
-              })}
-            </div>
-
-            <nav aria-label="Saved letters pagination" style={{ marginTop: 32 }}>
-              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage(1)}
-                  disabled={!canGoFirst}
-                  aria-disabled={!canGoFirst}
-                  aria-label="Go to first page"
-                >
-                  {'<<'}
-                </button>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-                  disabled={!canGoPrev}
-                  aria-disabled={!canGoPrev}
-                  aria-label="Go to previous page"
-                >
-                  {'<'}
-                </button>
-                <span aria-live="polite" style={{ fontWeight: 600 }}>
-                  Page {meta.page} of {Math.max(1, meta.totalPages)}
-                </span>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage((prev) => prev + 1)}
-                  disabled={!canGoNext}
-                  aria-disabled={!canGoNext}
-                  aria-label="Go to next page"
-                >
-                  {'>'}
-                </button>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setPage(meta.totalPages || 1)}
-                  disabled={!canGoLast}
-                  aria-disabled={!canGoLast}
-                  aria-label="Go to last page"
-                >
-                  {'>>'}
-                </button>
-              </div>
-            </nav>
+                    <span aria-hidden="true">‹</span>
+                  </button>
+                  <div style={{ textAlign: 'center', minWidth: 180 }}>
+                    <div style={{ fontWeight: 600, fontSize: '1.1rem' }}>
+                      Letter {displayIndex} of {Math.max(displayIndex, totalLetters)}
+                    </div>
+                    <div style={{ color: '#6b7280' }}>Page {currentPage} of {Math.max(1, meta.totalPages)}</div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleNextLetter}
+                    disabled={!canGoNextLetter}
+                    aria-disabled={!canGoNextLetter}
+                    aria-label="View next letter"
+                    style={{
+                      ...arrowButtonStyle,
+                      ...(canGoNextLetter ? {} : disabledArrowStyle),
+                    }}
+                  >
+                    <span aria-hidden="true">›</span>
+                  </button>
+                </div>
+              </nav>
+            )}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- present saved letters one at a time with enhanced arrow navigation and progress messaging
- reset the selected letter when filters or pagination change to keep navigation intuitive

## Testing
- npx nx test frontend --output-style=stream *(fails: Cannot find module 'jest')*
- npx tsc -p frontend/tsconfig.json --noEmit *(fails: missing frontend dev dependencies such as @tanstack/react-query)*

------
https://chatgpt.com/codex/tasks/task_e_68f92e336aa48321b0405edd02953dc0