### PR TITLE
feat(nest-modules): add redis integration module

### DIFF
--- a/nest-modules/src/index.ts
+++ b/nest-modules/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/nest-modules.module';
+export * from './lib/redis';

--- a/nest-modules/src/lib/nest-modules.module.ts
+++ b/nest-modules/src/lib/nest-modules.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 
+import { RedisModule } from './redis';
+
 @Module({
+  imports: [RedisModule],
   controllers: [],
   providers: [],
-  exports: [],
+  exports: [RedisModule],
 })
 export class NestModulesModule {}

--- a/nest-modules/src/lib/redis/index.ts
+++ b/nest-modules/src/lib/redis/index.ts
@@ -1,0 +1,2 @@
+export * from './redis.module';
+export * from './redis-client.service';

--- a/nest-modules/src/lib/redis/redis-client.service.ts
+++ b/nest-modules/src/lib/redis/redis-client.service.ts
@@ -1,0 +1,18 @@
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import type { Redis } from 'ioredis';
+
+@Injectable()
+export class RedisClientService implements OnModuleDestroy {
+  constructor(@InjectRedis() private readonly client: Redis) {}
+
+  getClient(): Redis {
+    return this.client;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.client.status !== 'end') {
+      await this.client.quit();
+    }
+  }
+}

--- a/nest-modules/src/lib/redis/redis.module.ts
+++ b/nest-modules/src/lib/redis/redis.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { RedisModule as IoRedisModule } from '@nestjs-modules/ioredis';
+
+import { RedisClientService } from './redis-client.service';
+
+@Module({
+  imports: [
+    IoRedisModule.forRootAsync({
+      useFactory: async () => {
+        const url = process.env.REDIS_URL;
+
+        if (!url) {
+          throw new Error('REDIS_URL environment variable is not defined.');
+        }
+
+        return {
+          config: {
+            url,
+          },
+        };
+      },
+    }),
+  ],
+  providers: [RedisClientService],
+  exports: [IoRedisModule, RedisClientService],
+})
+export class RedisModule {}


### PR DESCRIPTION
## Summary
- add a Redis module that configures a singleton client from the REDIS_URL environment variable
- provide a Redis client service that gracefully closes the connection during shutdown
- export the Redis module through the NestModulesModule entry point for external reuse

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa2ba2fee08321b2f3dd557c8229bd