### PR TITLE
Add Redis configuration and service to compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 
 # Backend API
 MONGO_URI=mongodb://localhost:27017/mp_writer
+# Redis connection string (leave blank to disable Redis usage)
+REDIS_URL=redis://localhost:6379/0
+# When using docker-compose the backend service overrides REDIS_URL to point at the
+# bundled Redis container. For manual setups, ensure this points at a reachable Redis
+# instance (e.g. redis://your-host:6379/0) and that Redis is running before starting the API.
 # Generate a strong random secret (>=32 chars), e.g. `openssl rand -hex 32`
 JWT_SECRET=
 APP_ORIGIN=http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,18 @@ services:
       retries: 20
       start_period: 5s
 
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
   backend-api:
     build:
       context: .
@@ -20,8 +32,11 @@ services:
     depends_on:
       mongo:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       - MONGO_URI=mongodb://mongo:27017/mp_writer
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET is required}
       - PORT=4000
       - APP_ORIGIN=http://localhost:3000


### PR DESCRIPTION
## Summary
- document the REDIS_URL configuration in the shared env example
- add a Redis service to docker-compose and expose REDIS_URL to the backend
- gate backend start-up on Redis health via depends_on

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa300eb07083218e1abec123f713db