### PR TITLE
feat: cache address lookups in redis

### DIFF
--- a/backend-api/src/user-address/addresses.controller.ts
+++ b/backend-api/src/user-address/addresses.controller.ts
@@ -1,11 +1,9 @@
 import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
 import { AddressesService } from './addresses.service';
-import { ConfigService } from '@nestjs/config';
-import { getAddressById } from './addresses.service';
 
 @Controller('addresses')
 export class AddressesController {
-  constructor(private readonly addresses: AddressesService, private readonly config: ConfigService) {}
+  constructor(private readonly addresses: AddressesService) {}
 
   @Get('lookup')
   async lookup(@Query('postcode') postcode?: string) {
@@ -17,7 +15,7 @@ export class AddressesController {
   @Get('get')
   async get(@Query('id') id?: string, @Query('postcode') postcode?: string) {
     if (!id) throw new BadRequestException('id is required');
-    const item = await getAddressById(this.config, id, postcode);
+    const item = await this.addresses.getAddressById(id, postcode);
     if (!item) throw new BadRequestException('Address not found');
     return { item };
   }

--- a/backend-api/src/user-address/addresses.module.ts
+++ b/backend-api/src/user-address/addresses.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AddressesService } from './addresses.service';
 import { AddressesController } from './addresses.controller';
 import { ConfigModule } from '@nestjs/config';
+import { RedisModule } from '@mp-writer/nest-modules';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, RedisModule],
   providers: [AddressesService],
   controllers: [AddressesController],
 })

--- a/backend-api/src/user-address/addresses.service.ts
+++ b/backend-api/src/user-address/addresses.service.ts
@@ -1,5 +1,6 @@
 import { BadGatewayException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { RedisClientService } from '@mp-writer/nest-modules';
 
 export interface NormalizedAddress {
   id: string;
@@ -19,11 +20,94 @@ function normalizePostcode(input: string) {
 
 @Injectable()
 export class AddressesService {
-  constructor(private readonly config: ConfigService) {}
+  private static readonly LOOKUP_CACHE_TTL_SECONDS = 60 * 60;
+  private static readonly ADDRESS_CACHE_TTL_SECONDS = 60 * 60;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly redisClientService: RedisClientService,
+  ) {}
+
+  private getSuggestionCacheKey(normalizedPostcode: string): string {
+    const tight = normalizedPostcode.replace(/\s+/g, '').toUpperCase();
+    return `addresses:suggestions:${tight}`;
+  }
+
+  private getAddressCacheKey(id: string): string {
+    return `addresses:details:${id}`;
+  }
+
+  private async readCache<T>(key: string): Promise<T | null> {
+    try {
+      const cached = await this.redisClientService.getClient().get(key);
+      if (!cached) return null;
+      return JSON.parse(cached) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeCache<T>(key: string, payload: T, ttlSeconds: number): Promise<void> {
+    try {
+      await this.redisClientService
+        .getClient()
+        .set(key, JSON.stringify(payload), 'EX', ttlSeconds);
+    } catch {
+      // Ignore cache write failures
+    }
+  }
+
+  private async deleteCache(key: string): Promise<void> {
+    try {
+      await this.redisClientService.getClient().del(key);
+    } catch {
+      // Ignore cache invalidation failures
+    }
+  }
+
+  private async readSuggestionsCache(postcode: string): Promise<NormalizedAddress[] | null> {
+    return this.readCache<NormalizedAddress[]>(this.getSuggestionCacheKey(postcode));
+  }
+
+  private async writeSuggestionsCache(postcode: string, addresses: NormalizedAddress[]): Promise<void> {
+    await this.writeCache(
+      this.getSuggestionCacheKey(postcode),
+      addresses,
+      AddressesService.LOOKUP_CACHE_TTL_SECONDS,
+    );
+  }
+
+  private async readAddressCache(id: string): Promise<NormalizedAddress | null> {
+    return this.readCache<NormalizedAddress>(this.getAddressCacheKey(id));
+  }
+
+  private async writeAddressCache(id: string, address: NormalizedAddress): Promise<void> {
+    await this.writeCache(
+      this.getAddressCacheKey(id),
+      address,
+      AddressesService.ADDRESS_CACHE_TTL_SECONDS,
+    );
+  }
+
+  async clearSuggestionsCache(postcode: string): Promise<void> {
+    const normalized = normalizePostcode(postcode || '');
+    if (!normalized) return;
+    await this.deleteCache(this.getSuggestionCacheKey(normalized));
+  }
+
+  async clearAddressCache(id: string): Promise<void> {
+    if (!id) return;
+    await this.deleteCache(this.getAddressCacheKey(id));
+  }
 
   async lookup(postcode: string): Promise<NormalizedAddress[]> {
     const pc = normalizePostcode(postcode || '');
     if (!pc) return [];
+
+    const cached = await this.readSuggestionsCache(pc);
+    if (cached) {
+      return cached;
+    }
 
     const getAddressKey = this.config.get<string>('GETADDRESS_API_KEY');
     const debug = this.config.get<string>('ADDRESS_DEBUG') === '1';
@@ -47,6 +131,7 @@ export class AddressesService {
         }
         if (res.status === 404) {
           if (debug) console.log('[addresses] No results for postcode');
+          await this.writeSuggestionsCache(pc, []);
           return [];
         }
         if (!res.ok) {
@@ -78,6 +163,7 @@ export class AddressesService {
           });
 
         if (debug) console.log(`[addresses] Returning ${addresses.length} suggestions (no prefetch)`);
+        await this.writeSuggestionsCache(pc, addresses);
         return addresses;
       } catch (e) {
         if (e instanceof BadGatewayException) throw e;
@@ -91,44 +177,52 @@ export class AddressesService {
         { id: 'm1', line1: '1 Example Street', line2: '', city: 'Exampletown', county: 'Example County', postcode: pc, label: `1 Example Street, Exampletown, Example County, ${pc}` },
         { id: 'm2', line1: '2 Sample Road', line2: 'Flat 3', city: 'Sampleton', county: 'Sample County', postcode: pc, label: `2 Sample Road, Flat 3, Sampleton, Sample County, ${pc}` },
       ];
+      await this.writeSuggestionsCache(pc, mock);
       return mock;
     }
 
     // In production, return empty list
+    await this.writeSuggestionsCache(pc, []);
     return [];
   }
-}
 
-// Separate function on the service to fetch a single full address by id.
-// This avoids N+1 request amplification during lookup.
-export async function getAddressById(config: ConfigService, id: string, defaultPostcode?: string): Promise<NormalizedAddress | null> {
-  const getAddressKey = config.get<string>('GETADDRESS_API_KEY');
-  const debug = config.get<string>('ADDRESS_DEBUG') === '1';
-  if (!getAddressKey) return null;
-  if (!id) return null;
+  async getAddressById(id: string, defaultPostcode?: string): Promise<NormalizedAddress | null> {
+    const getAddressKey = this.config.get<string>('GETADDRESS_API_KEY');
+    const debug = this.config.get<string>('ADDRESS_DEBUG') === '1';
+    if (!getAddressKey) return null;
+    if (!id) return null;
 
-  const url = `https://api.getaddress.io/get/${encodeURIComponent(id)}?api-key=${encodeURIComponent(getAddressKey)}`;
-  const logUrl = `https://api.getaddress.io/get/${encodeURIComponent(id)}`;
-  if (debug) console.log(`[addresses] GET ${logUrl}`);
-  const res = await fetch(url);
-  if (debug) console.log(`[addresses] <= ${res.status}`);
-  if (!res.ok) return null;
+    const cached = await this.readAddressCache(id);
+    if (cached) {
+      return cached;
+    }
 
-  const full: any = await res.json();
-  const line1 = (full.line_1 || `${full.building_number || ''} ${full.thoroughfare || ''}`).trim();
-  const line2 = (full.line_2 || '').trim();
-  const city = full.town_or_city || '';
-  const county = full.county || '';
-  const postcode = full.postcode || defaultPostcode || '';
-  const label = [line1, line2, city, county, postcode].filter(Boolean).join(', ');
+    const url = `https://api.getaddress.io/get/${encodeURIComponent(id)}?api-key=${encodeURIComponent(getAddressKey)}`;
+    const logUrl = `https://api.getaddress.io/get/${encodeURIComponent(id)}`;
+    if (debug) console.log(`[addresses] GET ${logUrl}`);
+    const res = await fetch(url);
+    if (debug) console.log(`[addresses] <= ${res.status}`);
+    if (!res.ok) return null;
 
-  return {
-    id: id.toString(),
-    line1,
-    line2,
-    city,
-    county,
-    postcode,
-    label,
-  } as NormalizedAddress;
+    const full: any = await res.json();
+    const line1 = (full.line_1 || `${full.building_number || ''} ${full.thoroughfare || ''}`).trim();
+    const line2 = (full.line_2 || '').trim();
+    const city = full.town_or_city || '';
+    const county = full.county || '';
+    const postcode = full.postcode || defaultPostcode || '';
+    const label = [line1, line2, city, county, postcode].filter(Boolean).join(', ');
+
+    const address: NormalizedAddress = {
+      id: id.toString(),
+      line1,
+      line2,
+      city,
+      county,
+      postcode,
+      label,
+    };
+
+    await this.writeAddressCache(id, address);
+    return address;
+  }
 }


### PR DESCRIPTION
## Summary
- inject the Redis client into the addresses service to cache postcode suggestions with a one-hour TTL
- cache resolved addresses by id with the same TTL and provide helpers to clear cached entries when data must be refreshed
- update the addresses module and controller wiring to use the Redis-backed service methods

## Testing
- npx nx lint backend-api *(fails: npm lockfile could not be parsed due to "Unexpected non-whitespace character after JSON at position 33")*

------
https://chatgpt.com/codex/tasks/task_e_68fa3d2660c48321805f6df47cc4179c