### PR TITLE
Add Redis operations documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Project skeleton generated with Nx (Next.js + NestJS) following the instructions
 Quick Start
 - Install Node.js 20+ and Docker
 - From the workspace root `mp-writer/`:
-  - Dev: First start MongoDB, then run backend and frontend in separate terminals:
-    - Terminal 1 (MongoDB): `docker compose up mongo`
+  - Dev: Start the data services, then run backend and frontend in separate terminals:
+    - Terminal 1 (MongoDB + Redis): `docker compose up mongo redis`
+      - See [docs/redis.md](docs/redis.md) for alternative Redis setups and env vars.
     - Terminal 2 (Backend): `PORT=4000 npx nx serve backend-api`
     - Terminal 3 (Frontend): `npx nx dev frontend` (runs on default port 3000)
   - Build: `npx nx build backend-api` and `npx nx build frontend`
@@ -17,6 +18,7 @@ Quick Start
 
 Environment
 - `MONGO_URI`: defaults to `mongodb://localhost:27017/mp_writer` when not set
+- `REDIS_URL`: required Redis connection string (e.g., `redis://localhost:6379/0`). Review [Redis operations](docs/redis.md) for guidance on connection limits and fallbacks.
 - `JWT_SECRET`: required for JWT issuance
 - `APP_ORIGIN`: frontend origin for CORS (e.g., `http://localhost:3000`)
 - Google OAuth: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL`

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,0 +1,39 @@
+# Redis Operations Guide
+
+This project relies on Redis for several backend concerns:
+
+- API rate limiting uses the Nest throttler with a Redis-backed store so limits work across every instance of the API service.
+- MP postcode lookups and address lookups cache upstream responses in Redis to keep external API usage under control.
+- AI runs use Redis streams and distributed locks to coordinate long-running jobs and real-time updates.
+
+## Connection management
+
+The shared `RedisClientService` wraps a single `ioredis` connection and exports it through Nest's dependency injection container. Each backend-api pod will therefore open exactly one long-lived connection. Size your Redis deployment so that `maxclients` comfortably exceeds `number_of_backend_replicas + 5` to leave headroom for maintenance shells or future workers. The default `maxclients` (10,000) on Redis 7 is sufficient for most environments.
+
+Configure the connection string via the required `REDIS_URL` environment variable. The value must be a full Redis URI (e.g. `redis://localhost:6379/0`).
+
+## Time-to-live defaults
+
+The backend applies the following TTL policies when writing to Redis:
+
+| Concern | Keys | TTL |
+| --- | --- | --- |
+| Address autocomplete & details | `addresses:suggestions:*`, `addresses:details:*` | 1 hour (3600 seconds) |
+| MP lookups by postcode | `mps:lookup:*` | 24 hours (86,400 seconds) |
+| Writing desk AI runs | Streams, metadata, and locks at `ai:run:*` | 5 minutes (300,000 ms) |
+| API rate limits | Global throttler counters | 60 seconds per 60 requests |
+
+## Behaviour when Redis is unavailable
+
+Caching layers (`MpsService` and `AddressesService`) catch Redis read/write errors and fall back to live requests, so lookups continue to work without cached acceleration.
+
+Features that need locking or throttling depend on Redis being reachable. The AI run service acquires Redis locks before starting work; if Redis is down the lock call will throw and the request will fail instead of starting a duplicate run. Likewise, the global rate limiter requires Redis; when it cannot connect the Nest throttler will bubble up errors, effectively failing requests until Redis returns. Ensure operators receive alerts when Redis is unhealthy.
+
+## Running Redis locally
+
+Choose any of the following approaches:
+
+- **Docker Compose** (runs alongside MongoDB and the app services): `docker compose up redis` from the repository root uses the configuration in `docker-compose.yml` (Redis 7 with a basic health check).
+- **Standalone Docker container**: `docker run --rm -p 6379:6379 redis:7` starts an ephemeral local instance; remember to set `REDIS_URL=redis://localhost:6379/0` in your environment or `.env` file.
+
+After starting Redis, export `REDIS_URL` in your shell or copy `.env.example` to `.env` and adjust the value before launching the backend service.


### PR DESCRIPTION
## Summary
- document Redis responsibilities, TTL defaults, and fallback behaviour
- link new Redis guide from the README quick start and environment sections

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68fa760ba0308321b1f7c96d58c46066